### PR TITLE
Ad  Install tags to stom_core and stomp_moveit

### DIFF
--- a/stomp_core/CMakeLists.txt
+++ b/stomp_core/CMakeLists.txt
@@ -17,7 +17,7 @@ add_definitions("-std=c++11")
 ###################################
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES stomp_core
+  LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS roscpp cmake_modules
   DEPENDS eigen
 )
@@ -47,6 +47,15 @@ target_link_libraries(${PROJECT_NAME}_example ${PROJECT_NAME} ${catkin_LIBRARIES
 #############
 ## Install ##
 #############
+install(TARGETS ${PROJECT_NAME}
+ ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+ LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+ RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+ DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
 
 
 #############

--- a/stomp_core/package.xml
+++ b/stomp_core/package.xml
@@ -9,9 +9,11 @@
   <author email="jrgnichodevel@gmail.com">Jorge Nicho</author>
   
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>eigen</build_depend>
+  <build_depend>roscpp</build_depend>
   <run_depend>cmake_modules</run_depend>
+  <run_depend>eigen</run_depend>
   <run_depend>roscpp</run_depend>
 
   <export>

--- a/stomp_moveit/CMakeLists.txt
+++ b/stomp_moveit/CMakeLists.txt
@@ -83,6 +83,11 @@ target_link_libraries(${PROJECT_NAME}_noise_generators ${catkin_LIBRARIES})
 #############
 ## Install ##
 #############
+install(TARGETS 
+ ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+ LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+ RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 #############
 ## Testing ##


### PR DESCRIPTION
Is it possible to add the install tags for stomp_core and stomp_moveit? So we can use it in our software and compile it with Travis.