### PR TITLE
Doxygen Fixes

### DIFF
--- a/constrained_ik/package.xml
+++ b/constrained_ik/package.xml
@@ -4,11 +4,11 @@
   <version>0.1.1</version>
   <description>Constraint-based IK solver.  Good for high-DOF robots or underconstrained tasks.</description>
 
-  <author email="cl__is@swri.org">Chris Lewis</author>
-  <author email="jz__s@swri.org">Jeremy Zoss</author>
-  <author email="dps____on@gmail.com">Dan Solomon</author>
+  <author email="clewis@swri.org">Chris Lewis</author>
+  <author email="jzoss@swri.org">Jeremy Zoss</author>
+  <author email="dpsolomon@gmail.com">Dan Solomon</author>
+  <maintainer email="levi.armstrong@gmail.com">Levi Armstrong</maintainer>
   <maintainer email="jzoss@swri.org">Jeremy Zoss, SwRI</maintainer>
-  <maintainer email="dpsolomon@gmail.com">Dan Solomon, SwRI</maintainer>
   <license>Apache 2.0</license>
   <url type="website">http://ros.org/wiki/constrained_ik</url>
 

--- a/doxygen.config
+++ b/doxygen.config
@@ -743,7 +743,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = constrained_ik
+INPUT                  = constrained_ik stomp_core stomp_moveit stomp_plugins
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/industrial_moveit/package.xml
+++ b/industrial_moveit/package.xml
@@ -2,10 +2,17 @@
   <name>industrial_moveit</name>
   <version>0.1.1</version>
   <description>ROS Industrial MoveIt packages.</description>
-  <author email="jz__s@swri.org">Jeremy Zoss</author>
-  <author email="dps____on@gmail.com">Dan Solomon</author>
-  <maintainer email="jzoss@swri.org">Jeremy Zoss</maintainer>
-  <maintainer email="dpsolomon@gmail.com">Dan Solomon</maintainer>
+  <author email="clewis@swri.org">Chris Lewis</author>
+  <author email="dpsolomon@gmail.com">Dan Solomon</author>
+  <author email="jzoss@swri.org">Jeremy Zoss</author>
+  <author email="levi.armstrong@gmail.com">Levi Armstrong</author>
+  <author email="jrgnichodevel@gmail.com">Jorge Nicho</author>
+  <author email="jonathan.meyer@swri.org">Jonathan Meyer</author>
+
+  <maintainer email="levi.armstrong@gmail.com">Levi Armstrong</maintainer>
+  <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
+  <maintainer email="jonathan.meyer@swri.org">Jonathan Meyer</maintainer>
+
   <license>Apache 2.0</license>
 
   <url type="website">http://ros.org/wiki/industrial_moveit</url>
@@ -15,6 +22,12 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <run_depend>constrained_ik</run_depend>
+  <run_depend>stomp_core</run_depend>
+  <run_depend>stomp_moveit</run_depend>
+  <run_depend>stomp_plugins</run_depend>
+  <run_depend>industrial_collision_detection</run_depend>
+  <run_depend>stomp_test_support</run_depend>
+  <run_depend>stomp_test_kr210_moveit_config</run_depend>
 
   <export>
     <metapackage/>

--- a/stomp_core/example_pages.dox
+++ b/stomp_core/example_pages.dox
@@ -1,5 +1,5 @@
 /**
-@page examples stomp_core examples
+@page stomp_core_examples stomp_core examples
 @tableofcontents
 @section stomp_core_example Optimize with STOMP
 The full example program can be found in file @ref stomp_example_code

--- a/stomp_core/mainpage.dox
+++ b/stomp_core/mainpage.dox
@@ -3,12 +3,12 @@
  * @htmlinclude manifest.html
  *
  * @section Description Description
- * This package containes the STOMP Core algorithm. The acronym STOMP,
+ * This package contains the STOMP Core algorithm. The acronym STOMP
  * stands for "Stochastic Trajectory Optimization for Motion Planning".
- * This planner can plan paths for high-dimensional robotic systems that
- * are collision-free, smooth, and can simultaneously satisfy task
- * constraints, minimize energy consumption, or optimize other arbitrary
- * criteria. STOMP is derived from gradient-free optimization and path
+ * This planner can produce smooths, collision-free paths for high-dimensional 
+ * robotic systems that satisfy various task constraints in order to minimize 
+ * energy consumption or optimize other user-chosen
+ * criteria. STOMP leverages gradient-free optimization and path
  * integral reinforcement learning techniques (Policy Improvement with
  * Path Integrals, Theodorou et al, 2010).
  *
@@ -26,5 +26,5 @@
  * limitations under the License.
  *
  * @section Examples
- * @ref examples
+ * @ref stomp_core_examples
  */

--- a/stomp_core/package.xml
+++ b/stomp_core/package.xml
@@ -7,6 +7,7 @@
   <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
   <license>Apache 2.0</license>
   <author email="jrgnichodevel@gmail.com">Jorge Nicho</author>
+  <url type="website">http://ros.org/wiki/stomp_core</url>
   
   <buildtool_depend>catkin</buildtool_depend>
 
@@ -19,5 +20,6 @@
   <run_depend>eigen</run_depend>
 
   <export>
+    <rosdoc config="rosdoc.yaml"/>
   </export>
 </package>

--- a/stomp_moveit/example_pages.dox
+++ b/stomp_moveit/example_pages.dox
@@ -1,5 +1,5 @@
 /**
-@page examples STOMP MoveIt! examples
+@page stomp_moveit_examples STOMP MoveIt! examples
 @tableofcontents
 @section stomp_moveit Plan with STOMP through MoveIt!
 
@@ -158,7 +158,7 @@ distances will lead to higher costs values for that state. Collisions will be se
     longest_valid_joint_move: 0.05 
 @endcode
   - class:        The class name
-  - max_distance: Used in calculating the cost as a function of the shortest distance.  The cost equals <b>abs(max_distance - d)/max_distance]</b>
+  - max_distance: Used in calculating the cost as a function of the shortest distance.  The cost equals <b>[(max_distance - d)/max_distance]</b>
                   If the shortest distance is greater than <b>max_distance</b> then the cost is set to zero.
   - cost_weight:  A weight value multiplied onto to each state cost.
   - longest_valid_joint_move: This value is used to check for collisions at intermediate poses between consecutive

--- a/stomp_moveit/include/stomp_moveit/cost_functions/collision_check.h
+++ b/stomp_moveit/include/stomp_moveit/cost_functions/collision_check.h
@@ -40,7 +40,7 @@ namespace cost_functions
  * @brief Assigns a cost value to  each robot state by evaluating if the robot is in collision.
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  */
 class CollisionCheck : public StompCostFunction
 {

--- a/stomp_moveit/include/stomp_moveit/cost_functions/obstacle_distance_gradient.h
+++ b/stomp_moveit/include/stomp_moveit/cost_functions/obstacle_distance_gradient.h
@@ -39,7 +39,7 @@ namespace cost_functions
  * @brief Assigns a cost value to  each robot state by evaluating the minimum distance between the robot and the nearest obstacle.
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  */
 class ObstacleDistanceGradient : public StompCostFunction
 {

--- a/stomp_moveit/include/stomp_moveit/cost_functions/stomp_cost_function.h
+++ b/stomp_moveit/include/stomp_moveit/cost_functions/stomp_cost_function.h
@@ -48,7 +48,7 @@ typedef boost::shared_ptr<StompCostFunction> StompCostFunctionPtr;
  * @brief The interface class for the STOMP cost functions.
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  */
 class StompCostFunction
 {

--- a/stomp_moveit/include/stomp_moveit/noise_generators/normal_distribution_sampling.h
+++ b/stomp_moveit/include/stomp_moveit/noise_generators/normal_distribution_sampling.h
@@ -40,7 +40,7 @@ namespace noise_generators
  * @brief Uses a normal distribution to apply noise onto the trajectory.
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  */
 class NormalDistributionSampling: public StompNoiseGenerator
 {

--- a/stomp_moveit/include/stomp_moveit/noise_generators/stomp_noise_generator.h
+++ b/stomp_moveit/include/stomp_moveit/noise_generators/stomp_noise_generator.h
@@ -48,7 +48,7 @@ typedef boost::shared_ptr<StompNoiseGenerator> StompNoiseGeneratorPtr;
  * @brief Interface class for plugins that apply random noise to the trajectory in order to explore the workspace.
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  */
 class StompNoiseGenerator
 {

--- a/stomp_moveit/include/stomp_moveit/noisy_filters/joint_limits.h
+++ b/stomp_moveit/include/stomp_moveit/noisy_filters/joint_limits.h
@@ -40,7 +40,7 @@ namespace noisy_filters
  *  the values of those joints that exceed the limits.
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  *
  */
 class JointLimits : public StompNoisyFilter

--- a/stomp_moveit/include/stomp_moveit/noisy_filters/multi_trajectory_visualization.h
+++ b/stomp_moveit/include/stomp_moveit/noisy_filters/multi_trajectory_visualization.h
@@ -43,7 +43,7 @@ namespace noisy_filters
  * @brief Publishes rviz markers to visualize the noisy trajectories
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  *
  */
 class MultiTrajectoryVisualization : public StompNoisyFilter

--- a/stomp_moveit/include/stomp_moveit/noisy_filters/stomp_noisy_filter.h
+++ b/stomp_moveit/include/stomp_moveit/noisy_filters/stomp_noisy_filter.h
@@ -49,7 +49,7 @@ typedef boost::shared_ptr<StompNoisyFilter> StompNoisyFilterPtr;
  * @brief Interface class for filtering noisy trajectories
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  */
 class StompNoisyFilter
 {

--- a/stomp_moveit/include/stomp_moveit/stomp_optimization_task.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_optimization_task.h
@@ -56,7 +56,7 @@ typedef std::shared_ptr<NoiseGeneratorLoader> NoiseGeneratorLoaderPtr;
  * @brief Loads and manages the STOMP plugins during the planning process.
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  *
  */
 class StompOptimizationTask: public stomp_core::Task

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -41,7 +41,7 @@ using StompOptimizationTaskPtr = boost::shared_ptr<StompOptimizationTask>;
  * @brief The PlanningContext specialization that wraps the STOMP algorithm.
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  *
  */
 class StompPlanner: public planning_interface::PlanningContext

--- a/stomp_moveit/include/stomp_moveit/stomp_planner_manager.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner_manager.h
@@ -36,7 +36,7 @@ namespace stomp_moveit
  * @brief The PlannerManager implementation that loads STOMP into moveit
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  *
  */
 class StompPlannerManager : public planning_interface::PlannerManager

--- a/stomp_moveit/include/stomp_moveit/update_filters/control_cost_projection.h
+++ b/stomp_moveit/include/stomp_moveit/update_filters/control_cost_projection.h
@@ -42,7 +42,7 @@ namespace update_filters
  *    The matrix is built using a numerical derivative method
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  *
  */
 class ControlCostProjection : public StompUpdateFilter

--- a/stomp_moveit/include/stomp_moveit/update_filters/polynomial_smoother.h
+++ b/stomp_moveit/include/stomp_moveit/update_filters/polynomial_smoother.h
@@ -53,7 +53,7 @@ namespace update_filters
  *   d - An array of the values corresponding to the constrained domain values
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  *
  */
 class PolynomialSmoother : public StompUpdateFilter

--- a/stomp_moveit/include/stomp_moveit/update_filters/stomp_update_filter.h
+++ b/stomp_moveit/include/stomp_moveit/update_filters/stomp_update_filter.h
@@ -46,7 +46,7 @@ namespace update_filters
  * @brief Interface class which applies filtering methods to the update parameters before it is added onto the optimized trajectory.
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  *
  */
 class StompUpdateFilter;

--- a/stomp_moveit/include/stomp_moveit/update_filters/trajectory_visualization.h
+++ b/stomp_moveit/include/stomp_moveit/update_filters/trajectory_visualization.h
@@ -43,7 +43,7 @@ namespace update_filters
  * @brief Publishes rviz markers to visualize the optimized trajectory
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  *
  */
 class TrajectoryVisualization : public StompUpdateFilter

--- a/stomp_moveit/include/stomp_moveit/update_filters/update_logger.h
+++ b/stomp_moveit/include/stomp_moveit/update_filters/update_logger.h
@@ -41,7 +41,7 @@ namespace update_filters
  *    'numpy.loadtxt(file_name)'
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  *
  */
 class UpdateLogger : public StompUpdateFilter

--- a/stomp_moveit/mainpage.dox
+++ b/stomp_moveit/mainpage.dox
@@ -34,7 +34,7 @@
  *      - @ref  update_logger_example 
  * 
  * @section Examples
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_moveit_examples
  *    
  * @section License
  * Software License Agreement (Apache License)

--- a/stomp_moveit/package.xml
+++ b/stomp_moveit/package.xml
@@ -7,6 +7,7 @@
   <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
   <license>Apache 2.0</license>
   <author email="jrgnichodevel@gmail.com">Jorge Nicho</author>
+  <url type="website">http://ros.org/wiki/stomp_moveit</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 
@@ -31,5 +32,6 @@
     <stomp_moveit plugin="${prefix}/noisy_filter_plugins.xml"/>
     <stomp_moveit plugin="${prefix}/update_filter_plugins.xml"/>
     <stomp_moveit plugin="${prefix}/noise_generator_plugins.xml"/>
+    <rosdoc config="rosdoc.yaml"/>
   </export>
 </package>

--- a/stomp_moveit/rosdoc.yaml
+++ b/stomp_moveit/rosdoc.yaml
@@ -1,2 +1,3 @@
 - builder: doxygen
   file_patterns: '*.cpp *.h *.dox *.launch *.yaml'
+  extract_all: NO

--- a/stomp_plugins/example_pages.dox
+++ b/stomp_plugins/example_pages.dox
@@ -1,5 +1,5 @@
 /**
-@page examples STOMP Plugins Examples
+@page stomp_plugins_examples STOMP Plugins Examples
 @tableofcontents
 @section stomp_plugins STOMP Plugins
 @subsection cost_functions_plugins Cost Function Plugins

--- a/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
+++ b/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
@@ -43,7 +43,7 @@ namespace cost_functions
  *        is from the desired under-constrained task manifold
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_plugins_examples
  */
 class ToolGoalPose: public StompCostFunction
 {

--- a/stomp_plugins/include/stomp_plugins/noise_generators/goal_guided_multivariate_gaussian.h
+++ b/stomp_plugins/include/stomp_plugins/noise_generators/goal_guided_multivariate_gaussian.h
@@ -45,7 +45,7 @@ typedef boost::variate_generator< RGNType, boost::uniform_real<> > RandomGenerat
  * @brief This class generates noisy trajectories to an under-constrained cartesian goal pose.
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_plugins_examples
  *
  */
 class GoalGuidedMultivariateGaussian: public StompNoiseGenerator

--- a/stomp_plugins/include/stomp_plugins/update_filters/constrained_cartesian_goal.h
+++ b/stomp_plugins/include/stomp_plugins/update_filters/constrained_cartesian_goal.h
@@ -40,7 +40,7 @@ namespace update_filters
  * @brief Forces the goal cartesian tool pose into the task space.
  *
  * @par Examples:
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_plugins_examples
  *
  */
 class ConstrainedCartesianGoal : public StompUpdateFilter

--- a/stomp_plugins/mainpage.dox
+++ b/stomp_plugins/mainpage.dox
@@ -16,7 +16,7 @@
  *      - ConstrainedCartesianGoal
  * 
  * @section Examples
- * All examples are located here @ref examples
+ * All examples are located here @ref stomp_plugins_examples
  *    
  * @section License
  * Software License Agreement (Apache License)

--- a/stomp_plugins/package.xml
+++ b/stomp_plugins/package.xml
@@ -7,6 +7,7 @@
   <maintainer email="jrgnichodevel@gmail.com">Jorge Nicho</maintainer>
   <license>Apache 2.0</license>
   <author email="jrgnichodevel@gmail.com">Jorge Nicho</author>
+  <url type="website">http://ros.org/wiki/stomp_plugins</url>
 
   <buildtool_depend>catkin</buildtool_depend>
 
@@ -34,5 +35,6 @@
     <stomp_moveit plugin="${prefix}/noise_generator_plugins.xml"/>    
     <stomp_moveit plugin="${prefix}/cost_function_plugins.xml"/>
     <stomp_moveit plugin="${prefix}/update_filter_plugins.xml"/>
+    <rosdoc config="rosdoc.yaml"/>
   </export>
 </package>


### PR DESCRIPTION
This PR contains a number of fixes that resolve issues with documentation links pointing to the wrong pages. In addition to that, it does the following:
- Fixes author and maintainer names
- Adds packages names to the package.xml of the industrial_moveit metapackage.
- Fixes minor typos

@Levi-Armstrong  please review