### PR TITLE
install plugin description for external plugin interfaces

### DIFF
--- a/constrained_ik/CMakeLists.txt
+++ b/constrained_ik/CMakeLists.txt
@@ -160,6 +160,16 @@ install(DIRECTORY include/${PROJECT_NAME}/
   PATTERN ".svn" EXCLUDE
 )
 
+install(
+  FILES
+    constrained_ik_constraint_plugin_description.xml
+    constrained_ik_planner_plugin_description.xml
+    constrained_ik_plugin.xml
+  DESTINATION
+    ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+
 ## Mark other files for installation (e.g. launch and bag files, etc.)
 # install(FILES
 #   # myfile1

--- a/industrial_collision_detection/CMakeLists.txt
+++ b/industrial_collision_detection/CMakeLists.txt
@@ -65,3 +65,9 @@ install(TARGETS ${PROJECT_NAME}
         ARCHIVE DESTINATION lib)
 install(DIRECTORY include/
   DESTINATION include)
+install(
+  FILES
+    industrial_collision_detection_plugin_description.xml
+  DESTINATION
+    ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/stomp_moveit/CMakeLists.txt
+++ b/stomp_moveit/CMakeLists.txt
@@ -84,6 +84,13 @@ target_link_libraries(${PROJECT_NAME}_noise_generators ${catkin_LIBRARIES})
 ## Install ##
 #############
 
+install(
+  FILES
+    planner_manager_plugins.xml
+  DESTINATION
+    ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
 #############
 ## Testing ##
 #############


### PR DESCRIPTION
Even if you don't actually *use* stomp,
but just build it in your install-workspace,
moveit will complain about these missing descriptions.

I believe there are more install rules needed to get stomp
to work in an install-workspace, but this removes the big red error
messages on startup of a non-stomp MoveIt configuration.