### PR TITLE
Update stomp plugins ik code

### DIFF
--- a/stomp_core/include/stomp_core/stomp.h
+++ b/stomp_core/include/stomp_core/stomp.h
@@ -186,7 +186,6 @@ protected:
   double parameters_total_cost_;                   /**< @brief Total cost of the optimized parameters */
   double current_lowest_cost_;                     /**< @brief Hold the lowest cost of the optimized parameters */
   Eigen::MatrixXd parameters_optimized_;           /**< @brief A matrix [dimensions][timesteps] of the optimized parameters. */
-  Eigen::MatrixXd parameters_optimized_prev_;      /**< @brief A matrix [dimensions][timesteps] of the optimized parameters in the previous iteration. */
 
   Eigen::MatrixXd parameters_updates_;             /**< @brief A matrix [dimensions][timesteps] of the parameter updates*/
   Eigen::VectorXd parameters_state_costs_;         /**< @brief A vector [timesteps] of the parameters state costs */

--- a/stomp_core/include/stomp_core/stomp.h
+++ b/stomp_core/include/stomp_core/stomp.h
@@ -182,9 +182,12 @@ protected:
 
   // optimized parameters
   bool parameters_valid_;                          /**< @brief whether or not the optimized parameters are valid */
+  bool parameters_valid_prev_;                     /**< @brief whether or not the optimized parameters from the previous iteration are valid */
   double parameters_total_cost_;                   /**< @brief Total cost of the optimized parameters */
   double current_lowest_cost_;                     /**< @brief Hold the lowest cost of the optimized parameters */
   Eigen::MatrixXd parameters_optimized_;           /**< @brief A matrix [dimensions][timesteps] of the optimized parameters. */
+  Eigen::MatrixXd parameters_optimized_prev_;      /**< @brief A matrix [dimensions][timesteps] of the optimized parameters in the previous iteration. */
+
   Eigen::MatrixXd parameters_updates_;             /**< @brief A matrix [dimensions][timesteps] of the parameter updates*/
   Eigen::VectorXd parameters_state_costs_;         /**< @brief A vector [timesteps] of the parameters state costs */
   Eigen::MatrixXd parameters_control_costs_;       /**< @brief A matrix [dimensions][timesteps] of the parameters control costs*/

--- a/stomp_core/src/stomp.cpp
+++ b/stomp_core/src/stomp.cpp
@@ -248,7 +248,6 @@ bool Stomp::solve(const Eigen::MatrixXd& initial_parameters,
     return false;
   }
 
-  parameters_optimized_prev_ = parameters_optimized_;
   parameters_valid_prev_ = parameters_valid_;
   while(current_iteration_ <= config_.num_iterations && runSingleIteration())
   {
@@ -801,7 +800,8 @@ bool Stomp::computeOptimizedCost()
     {
       if(parameters_valid_prev_)
       {
-        parameters_optimized_ = parameters_optimized_prev_;
+        // reverting updates as no improvement was made
+        parameters_optimized_ -= parameters_updates_;
       }
     }
     else
@@ -811,7 +811,6 @@ bool Stomp::computeOptimizedCost()
     }
   }
 
-  parameters_optimized_prev_ = parameters_optimized_;
   parameters_valid_prev_ = parameters_valid_;
 
   return true;

--- a/stomp_core/src/stomp.cpp
+++ b/stomp_core/src/stomp.cpp
@@ -512,6 +512,11 @@ bool Stomp::generateNoisyRollouts()
   // generate new noisy rollouts
   for(auto r = 0u; r < rollouts_generate; r++)
   {
+    if(!proceed_)
+    {
+      return false;
+    }
+
     if(!task_->generateNoisyParameters(parameters_optimized_,
                                       0,config_.num_timesteps,
                                       current_iteration_,r,
@@ -536,6 +541,11 @@ bool Stomp::filterNoisyRollouts()
   bool filtered = false;
   for(auto r = 0u ; r < config_.num_rollouts; r++)
   {
+    if(!proceed_)
+    {
+      return false;
+    }
+
     if(!task_->filterNoisyParameters(0,config_.num_timesteps,current_iteration_,r,noisy_rollouts_[r].parameters_noise,filtered))
     {
       ROS_ERROR_STREAM("Failed to filter noisy parameters");

--- a/stomp_core/src/stomp.cpp
+++ b/stomp_core/src/stomp.cpp
@@ -803,25 +803,18 @@ bool Stomp::computeOptimizedCost()
   if(current_lowest_cost_ > parameters_total_cost_)
   {
     current_lowest_cost_ = parameters_total_cost_;
+    parameters_valid_prev_ = parameters_valid_;
   }
   else
   {
-    if(parameters_valid_)
-    {
-      if(parameters_valid_prev_)
-      {
-        // reverting updates as no improvement was made
-        parameters_optimized_ -= parameters_updates_;
-      }
-    }
-    else
+    if(parameters_valid_prev_)
     {
       // reverting updates as no improvement was made
       parameters_optimized_ -= parameters_updates_;
+      parameters_valid_ = parameters_valid_prev_;
+
     }
   }
-
-  parameters_valid_prev_ = parameters_valid_;
 
   return true;
 }

--- a/stomp_core/src/stomp.cpp
+++ b/stomp_core/src/stomp.cpp
@@ -248,6 +248,8 @@ bool Stomp::solve(const Eigen::MatrixXd& initial_parameters,
     return false;
   }
 
+  parameters_optimized_prev_ = parameters_optimized_;
+  parameters_valid_prev_ = parameters_valid_;
   while(current_iteration_ <= config_.num_iterations && runSingleIteration())
   {
 
@@ -788,15 +790,29 @@ bool Stomp::computeOptimizedCost()
     return false;
   }
 
+  // stop optimizing when valid solution is found
   if(current_lowest_cost_ > parameters_total_cost_)
   {
     current_lowest_cost_ = parameters_total_cost_;
   }
   else
   {
-    // reverting updates as no improvement was made
-    parameters_optimized_ -= parameters_updates_;
+    if(parameters_valid_)
+    {
+      if(parameters_valid_prev_)
+      {
+        parameters_optimized_ = parameters_optimized_prev_;
+      }
+    }
+    else
+    {
+      // reverting updates as no improvement was made
+      parameters_optimized_ -= parameters_updates_;
+    }
   }
+
+  parameters_optimized_prev_ = parameters_optimized_;
+  parameters_valid_prev_ = parameters_valid_;
 
   return true;
 }

--- a/stomp_moveit/CMakeLists.txt
+++ b/stomp_moveit/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   kdl_parser
   trac_ik_lib
 )
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
 
 add_definitions("-std=c++11")
@@ -23,7 +23,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS moveit_ros_planning moveit_core stomp_core cmake_modules pluginlib roscpp kdl_parser trac_ik_lib
-  DEPENDS Eigen
+  DEPENDS EIGEN3
 )
 
 ###########

--- a/stomp_moveit/CMakeLists.txt
+++ b/stomp_moveit/CMakeLists.txt
@@ -7,6 +7,8 @@ find_package(catkin REQUIRED COMPONENTS
   stomp_core
   cmake_modules
   pluginlib
+  kdl_parser
+  trac_ik_lib
 )
 find_package(Eigen REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
@@ -20,7 +22,7 @@ add_definitions("-std=c++11")
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS moveit_ros_planning moveit_core stomp_core cmake_modules pluginlib roscpp
+  CATKIN_DEPENDS moveit_ros_planning moveit_core stomp_core cmake_modules pluginlib roscpp kdl_parser trac_ik_lib
   DEPENDS Eigen
 )
 
@@ -38,6 +40,7 @@ add_library(${PROJECT_NAME}
   src/stomp_optimization_task.cpp
   src/stomp_planner.cpp
   src/utils/polynomial.cpp
+  src/utils/kinematics.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/stomp_moveit/CMakeLists.txt
+++ b/stomp_moveit/CMakeLists.txt
@@ -1,11 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(stomp_moveit)
-
-add_definitions("-std=c++11")
-
-find_package(Eigen3 REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system)
-
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   moveit_core
@@ -14,6 +8,11 @@ find_package(catkin REQUIRED COMPONENTS
   cmake_modules
   pluginlib
 )
+find_package(Eigen REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
+
+add_definitions("-std=c++11")
+
 
 ###################################
 ## catkin specific configuration ##
@@ -22,7 +21,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS moveit_ros_planning moveit_core stomp_core cmake_modules pluginlib roscpp
-  DEPENDS EIGEN3
+  DEPENDS Eigen
 )
 
 ###########
@@ -31,8 +30,7 @@ catkin_package(
 
 ## Specify additional locations of header files
 include_directories(include
-  ${catkin_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIRS}
+    ${catkin_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library
@@ -60,7 +58,7 @@ target_link_libraries(${PROJECT_NAME}_cost_functions ${catkin_LIBRARIES})
 
 # filter plugin(s)
 add_library(${PROJECT_NAME}_noisy_filters
-  src/noisy_filters/joint_limits.cpp
+  src/noisy_filters/joint_limits.cpp  
   src/noisy_filters/multi_trajectory_visualization.cpp
 )
 
@@ -91,7 +89,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 )
 
 ## Mark executables and/or libraries for installation
-install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_planner_manager ${PROJECT_NAME}_cost_functions
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_planner_manager ${PROJECT_NAME}_cost_functions 
   ${PROJECT_NAME}_noisy_filters ${PROJECT_NAME}_update_filters ${PROJECT_NAME}_noise_generators
 ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -112,3 +110,4 @@ install(
 #############
 ## Testing ##
 #############
+

--- a/stomp_moveit/include/stomp_moveit/noisy_filters/joint_limits.h
+++ b/stomp_moveit/include/stomp_moveit/noisy_filters/joint_limits.h
@@ -99,6 +99,7 @@ protected:
   // options
   bool lock_start_;
   bool lock_goal_;
+  bool has_goal_constraints_;  /** @brief  True if a joint constraint for the goal was provided*/
 
   // start and goal
   moveit::core::RobotStatePtr start_state_;

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -29,6 +29,7 @@
 #include <moveit/planning_interface/planning_interface.h>
 #include <stomp_core/stomp.h>
 #include <stomp_moveit/stomp_optimization_task.h>
+#include <stomp_moveit/utils/kinematics.h>
 #include <boost/thread.hpp>
 #include <ros/ros.h>
 
@@ -121,16 +122,6 @@ protected:
   bool getStartAndGoal(Eigen::VectorXd& start, Eigen::VectorXd& goal);
 
   /**
-   * @brief Generates one or more joint poses from a cartesian goal
-   * @param start_state
-   * @param goal
-   * @param goal_poses
-   * @return
-   */
-  bool cartesianConstraintstoJointSolutions(moveit::core::RobotStateConstPtr start_state,const moveit_msgs::Constraints& goal,
-                                    std::vector<Eigen::VectorXd>& joint_solutions) const;
-
-  /**
    * @brief This function 1) gets the seed trajectory from the active motion plan request, 2) checks to see if
    * the given seed trajectory makes sense in the context of the user provided goal constraints, 3) modifies
    * the seed's first and last point to 'fix' it for small deviations in the goal constraints and 4) applies
@@ -173,8 +164,9 @@ protected:
   XmlRpc::XmlRpcValue config_;
   stomp_core::StompConfiguration stomp_config_;
 
-  // robot environment
+  // robot model
   moveit::core::RobotModelConstPtr robot_model_;
+  utils::kinematics::IKSolverPtr ik_solver_;
 
   // ros tasks
   ros::NodeHandlePtr ph_;

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -121,6 +121,16 @@ protected:
   bool getStartAndGoal(Eigen::VectorXd& start, Eigen::VectorXd& goal);
 
   /**
+   * @brief Generates one or more joint poses from a cartesian goal
+   * @param start_state
+   * @param goal
+   * @param goal_poses
+   * @return
+   */
+  bool cartesianConstraintstoJointSolutions(moveit::core::RobotStateConstPtr start_state,const moveit_msgs::Constraints& goal,
+                                    std::vector<Eigen::VectorXd>& joint_solutions) const;
+
+  /**
    * @brief This function 1) gets the seed trajectory from the active motion plan request, 2) checks to see if
    * the given seed trajectory makes sense in the context of the user provided goal constraints, 3) modifies
    * the seed's first and last point to 'fix' it for small deviations in the goal constraints and 4) applies

--- a/stomp_moveit/include/stomp_moveit/utils/kinematics.h
+++ b/stomp_moveit/include/stomp_moveit/utils/kinematics.h
@@ -37,6 +37,7 @@
 #include <moveit_msgs/PositionConstraint.h>
 #include <moveit_msgs/OrientationConstraint.h>
 #include <trac_ik/trac_ik.hpp>
+#include <boost/optional.hpp>
 
 
 namespace stomp_moveit
@@ -128,8 +129,13 @@ namespace kinematics
 
   };
 
-
-  bool validateCartesianConstraints(const moveit_msgs::Constraints& c);
+  /**
+   * @brief Checks if the constraint structured contains valid data from which a proper cartesian constraint can
+   *        be produced.
+   * @param c   The constraint object. It may define position, orientation or both constraint types.
+   * @return True when it is Cartesian, false otherwise.
+   */
+  bool isCartesianConstraints(const moveit_msgs::Constraints& c);
 
   /**
    * @brief Populates the missing parts of a Cartesian constraints in order to provide a constraint that can be used by the Ik solver.
@@ -137,9 +143,9 @@ namespace kinematics
    * @param ref_pose        If no orientation or position constraints are given then this pose will be use to fill the missing information.
    * @param default_pos_tol Used when no position tolerance is specified.
    * @param default_rot_tol Used when no rotation tolerance is specified
-   * @return
+   * @return  A constraint object
    */
-  moveit_msgs::Constraints constructCartesianConstraints(const moveit_msgs::Constraints& c,const Eigen::Affine3d& ref_pose,
+  boost::optional<moveit_msgs::Constraints> curateCartesianConstraints(const moveit_msgs::Constraints& c,const Eigen::Affine3d& ref_pose,
                                                                 double default_pos_tol = 0.0005, double default_rot_tol = M_PI);
 
   /**

--- a/stomp_moveit/include/stomp_moveit/utils/kinematics.h
+++ b/stomp_moveit/include/stomp_moveit/utils/kinematics.h
@@ -118,34 +118,6 @@ namespace kinematics
 
   };
 
-  /**
-   * @struct stomp_moveit::utils::KinematicConfig
-   * @brief Convenience structure that contains the variables used in solving for an ik solution.
-   */
-  struct KinematicConfig
-  {
-    /** @name Constraint Parameters
-     * The constraints on the cartesian goal
-     */
-    Eigen::Array<int,6,1> constrained_dofs = Eigen::Array<int,6,1>::Ones(); /**< @brief  A vector of the form [x y z rx ry rz] filled with 0's and 1's
-                                                                                        to indicate an unconstrained or fully constrained DOF. **/
-    Eigen::Affine3d tool_goal_pose = Eigen::Affine3d::Identity();           /**< @brief  The desired tool pose. **/
-
-    /** @name Support Parameters
-     * Used at each iteration until a solution is found
-     */
-    Eigen::ArrayXd joint_update_rates = Eigen::ArrayXd::Zero(1,1);          /**< @brief The weights to be applied to each update during every iteration [num_dimensions x 1]. **/
-    Eigen::Array<double,6,1> cartesian_convergence_thresholds = Eigen::Array<double,6,1>::Zero(); /**< @brief  The error margin for each dimension of the twist vector [6 x 1]. **/
-    Eigen::VectorXd init_joint_pose = Eigen::ArrayXd::Zero(1,1);            /**< @brief  Seed joint pose [num_dimension x 1]. **/
-    int max_iterations = 100;                                               /**< @brief  The maximum number of iterations that the algorithm will run until convergence is reached. **/
-
-    /** @name Null Space Parameters
-     * Used in exploding the task manifold null space
-     */
-    Eigen::ArrayXd null_proj_weights = Eigen::ArrayXd::Zero(1,1);  /**< @brief Weights to be applied to the null space vector */
-    Eigen::VectorXd null_space_vector = Eigen::VectorXd::Zero(1);  /**< @brief Null space vector that is used to exploit the Jacobian's null space */
-
-  };
 
   static bool validateCartesianConstraints(const moveit_msgs::Constraints& c)
   {
@@ -160,71 +132,25 @@ namespace kinematics
    * @param default_rot_tol Used when no rotation tolerance is specified
    * @return
    */
-  static moveit_msgs::Constraints constructCartesianConstraints(const moveit_msgs::Constraints& c,const Eigen::Affine3d& ref_pose,
-                                                                double default_pos_tol = 0.0005, double default_rot_tol = M_PI)
-  {
-    using namespace moveit_msgs;
+  moveit_msgs::Constraints constructCartesianConstraints(const moveit_msgs::Constraints& c,const Eigen::Affine3d& ref_pose,
+                                                                double default_pos_tol = 0.0005, double default_rot_tol = M_PI);
 
-    moveit_msgs::Constraints cc;
-    int num_pos_constraints = c.position_constraints.size();
-    int num_orient_constraints = c.orientation_constraints.size();
-    int num_entries = num_pos_constraints >= num_orient_constraints ? num_pos_constraints : num_orient_constraints;
-
-    if(!validateCartesianConstraints(c))
-    {
-      return cc;
-    }
-
-    // creating default position constraint
-    PositionConstraint pc;
-    pc.constraint_region.primitive_poses.resize(1);
-    tf::poseEigenToMsg(Eigen::Affine3d::Identity(), pc.constraint_region.primitive_poses[0]);
-    pc.constraint_region.primitive_poses[0].position.x = ref_pose.translation().x();
-    pc.constraint_region.primitive_poses[0].position.y = ref_pose.translation().y();
-    pc.constraint_region.primitive_poses[0].position.z = ref_pose.translation().z();
-    shape_msgs::SolidPrimitive shape;
-    shape.type = shape.SPHERE;
-    shape.dimensions.push_back(default_pos_tol);
-    pc.constraint_region.primitives.push_back(shape);
-
-    // creating default orientation constraint
-    OrientationConstraint oc;
-    oc.absolute_x_axis_tolerance = default_rot_tol;
-    oc.absolute_y_axis_tolerance = default_rot_tol;
-    oc.absolute_z_axis_tolerance = default_rot_tol;
-    oc.orientation.x = oc.orientation.y = oc.orientation.z = 0;
-    oc.orientation.w = 1;
-
-
-    cc.position_constraints.resize(num_entries);
-    cc.orientation_constraints.resize(num_entries);
-    for(int i =0; i < num_entries; i++)
-    {
-      // populating position constraints
-      if(c.position_constraints.size() >= num_entries)
-      {
-        cc.position_constraints[i] = c.position_constraints[i];
-      }
-      else
-      {
-        cc.position_constraints[i] = pc;
-      }
-
-      // populating orientation constraints
-      if(c.orientation_constraints.size() >= num_entries)
-      {
-        cc.orientation_constraints[i] = c.orientation_constraints[i];
-      }
-      else
-      {
-        cc.orientation_constraints[i] = oc;
-      }
-    }
-
-    return cc;
-  }
-
+  /**
+   * @brief Extracts the cartesian data from the constraint message
+   * @param constraints A moveit_msgs message that encapsulates the cartesian constraints specifications.
+   * @param tool_pose   The tool pose as specified in the constraint message.
+   * @param tolerance   The tolerance values on the tool pose as specified in the constraint message.
+   * @return True if succeeded, false otherwise.
+   */
   bool decodeCartesianConstraint(const moveit_msgs::Constraints& constraints, Eigen::Affine3d& tool_pose, std::vector<double>& tolerance);
+
+  /**
+   * @brief Extracts the cartesian data from the constraint message
+   * @param constraints A moveit_msgs message that encapsulates the cartesian constraints specifications.
+   * @param tool_pose   The tool pose as specified in the constraint message.
+   * @param tolerance   The tolerance values on the tool pose as specified in the constraint message.
+   * @return  True if succeeded, false otherwise.
+   */
   bool decodeCartesianConstraint(const moveit_msgs::Constraints& constraints, Eigen::Affine3d& tool_pose, Eigen::VectorXd& tolerance);
 
   /**
@@ -234,152 +160,10 @@ namespace kinematics
    * @param max_samples           Maximum number of samples to be generated
    * @return The sampled poses
    */
-  static std::vector<Eigen::Affine3d> sampleCartesianPoses(const moveit_msgs::Constraints& c,
+  std::vector<Eigen::Affine3d> sampleCartesianPoses(const moveit_msgs::Constraints& c,
                                                     const std::vector<double> sampling_resolution = {0.05, 0.05, 0.05, M_PI_2,M_PI_2,M_PI_2},
                                                     int max_samples =20 );
 
-  /**
-   * @brief Populates a Kinematic Config struct from the position and orientation constraints requested;
-   * @param group             A pointer to the JointModelGroup
-   * @param pc                The position constraint message
-   * @param oc                The orientation constraint message.  Absolute tolerances greater than 2PI will be considered unconstrained.
-   * @param init_joint_pose   The initial joint values
-   * @param kc                The output KinematicConfig object
-   * @return  True if succeeded, false otherwise
-   */
-  static bool createKinematicConfig(const moveit::core::JointModelGroup* group,
-                                               const moveit_msgs::PositionConstraint& pc,const moveit_msgs::OrientationConstraint& oc,
-                                               const Eigen::VectorXd& init_joint_pose,KinematicConfig& kc)
-  {
-    using namespace moveit::core;
-
-    int num_joints = group->getActiveJointModelNames().size();
-    const std::vector<const JointModel* >& joint_models = group->getActiveJointModels();
-
-    if(num_joints != init_joint_pose.size())
-    {
-      ROS_ERROR("Initial joint pose has an incorrect number of joints");
-      return false;
-    }
-
-    // tool pose position
-    kc.tool_goal_pose.setIdentity();
-    auto& v = pc.constraint_region.primitive_poses[0].position;
-    kc.tool_goal_pose.translation() = Eigen::Vector3d(v.x,v.y,v.z);
-
-    // tool pose orientation
-    Eigen::Quaterniond q;
-    tf::quaternionMsgToEigen(oc.orientation,q);
-    kc.tool_goal_pose.rotate(q);
-
-    // defining constraints
-    kc.constrained_dofs << 1, 1, 1, 1, 1, 1;
-
-    const shape_msgs::SolidPrimitive& bv = pc.constraint_region.primitives[0];
-    switch(bv.type)
-    {
-      case shape_msgs::SolidPrimitive::BOX :
-      {
-        if(bv.dimensions.size() != 3)
-        {
-          ROS_ERROR("Position constraint for BOX shape incorrectly defined, only 3 dimensions entries are needed");
-          return false;
-        }
-
-        using SP = shape_msgs::SolidPrimitive;
-        kc.cartesian_convergence_thresholds[0] = bv.dimensions[SP::BOX_X];
-        kc.cartesian_convergence_thresholds[1] = bv.dimensions[SP::BOX_Y];
-        kc.cartesian_convergence_thresholds[2] = bv.dimensions[SP::BOX_Z];
-      }
-      break;
-
-      case shape_msgs::SolidPrimitive::SPHERE:
-      {
-        if(bv.dimensions.size() != 1)
-        {
-          ROS_ERROR("Position constraint for SPHERE shape has no valid dimensions");
-          return false;
-        }
-
-        using SP = shape_msgs::SolidPrimitive;
-        kc.cartesian_convergence_thresholds[0] = bv.dimensions[SP::SPHERE_RADIUS];
-        kc.cartesian_convergence_thresholds[1] = bv.dimensions[SP::SPHERE_RADIUS];
-        kc.cartesian_convergence_thresholds[2] = bv.dimensions[SP::SPHERE_RADIUS];
-      }
-      break;
-
-      default:
-
-        ROS_ERROR("The Position constraint shape %i isn't supported",bv.type);
-        return false;
-    }
-
-    // orientation tolerance
-    kc.cartesian_convergence_thresholds[3] = oc.absolute_x_axis_tolerance;
-    kc.cartesian_convergence_thresholds[4] = oc.absolute_y_axis_tolerance;
-    kc.cartesian_convergence_thresholds[5] = oc.absolute_z_axis_tolerance;
-
-    // unconstraining orientation dofs that exceed 2pi
-    for(std::size_t i = 3; i < kc.cartesian_convergence_thresholds.size(); i++)
-    {
-      auto v = kc.cartesian_convergence_thresholds[i];
-      kc.constrained_dofs[i] = v >= 2*M_PI ? 0 : 1;
-    }
-
-    // setting up joint update rates
-    kc.joint_update_rates = Eigen::ArrayXd::Constant(num_joints,0.5f);
-    for(std::size_t i = 0 ; i < num_joints; i++)
-    {
-      const JointModel* jm = joint_models[i];
-
-      if(jm->getType() == JointModel::REVOLUTE)
-      {
-        kc.joint_update_rates(i) = 0.5;
-      }
-      else if(jm->getType() == JointModel::PRISMATIC)
-      {
-        kc.joint_update_rates(i) = 0.05;
-      }
-    }
-
-    // additional variables
-    kc.init_joint_pose = init_joint_pose;
-    kc.max_iterations = 100;
-
-    return true;
-  }
-
-  /**
-   * @brief Populates a Kinematic Config struct from the position and orientation constraints requested;
-   * @param group         A pointer to the JointModelGroup
-   * @param pc            The position constraint message
-   * @param oc            The orientation constraint message.  Absolute tolerances greater than 2PI will be considered unconstrained.
-   * @param start_state   The start robot state message
-   * @param kc            The output KinematicConfig object
-   * @return    True if succeeded, false otherwise
-   */
-  static bool createKinematicConfig(const moveit::core::JointModelGroup* group,
-                                               const moveit_msgs::PositionConstraint& pc,const moveit_msgs::OrientationConstraint& oc,
-                                               const moveit_msgs::RobotState& start_state,KinematicConfig& kc)
-  {
-    const auto& joint_names= group->getActiveJointModelNames();
-    const auto& jstate = start_state.joint_state;
-    std::size_t ind = 0;
-    Eigen::VectorXd joint_vals = Eigen::VectorXd::Zero(joint_names.size());
-    for(std::size_t i = 0; i < joint_names.size();i ++)
-    {
-      auto pos = std::find(jstate.name.begin(),jstate.name.end(),joint_names[i]);
-      if(pos == jstate.name.end())
-      {
-        return false;
-      }
-
-      ind = std::distance(jstate.name.begin(),pos);
-      joint_vals(i) = jstate.position[ind];
-    }
-
-    return createKinematicConfig(group,pc,oc,joint_vals,kc);
-  }
 
 /**
  * @brief Computes the twist vector [vx vy vz wx wy wz]'  relative to the current tool coordinate system.  The rotational part is
@@ -390,41 +174,9 @@ namespace kinematics
  * @param nullity   array of 0's and 1's indicating which cartesian DOF's are unconstrained (0)
  * @param twist     the twist vector in tool coordinates (change from p0 to pf) [6 x 1].
  */
-  static void computeTwist(const Eigen::Affine3d& p0,
+  void computeTwist(const Eigen::Affine3d& p0,
                                           const Eigen::Affine3d& pf,
-                                          const Eigen::ArrayXi& nullity,Eigen::VectorXd& twist)
-  {
-    twist.resize(nullity.size());
-    twist.setConstant(0);
-
-    // relative transform
-    auto p0_inv = p0.inverse();
-    Eigen::Affine3d t = (p0_inv) * pf;
-
-    Eigen::Vector3d twist_pos = p0_inv.rotation()*(pf.translation() - p0.translation());
-
-    // relative rotation -> R = inverse(R0) * Rf
-    Eigen::AngleAxisd relative_rot(t.rotation());
-    double angle = relative_rot.angle();
-    Eigen::Vector3d axis = relative_rot.axis();
-
-    // forcing angle to range [-pi , pi]
-    while( (angle > M_PI) || (angle < -M_PI))
-    {
-      angle = (angle >  M_PI) ? (angle - 2*M_PI) : angle;
-      angle = (angle < -M_PI )? (angle + 2*M_PI) : angle;
-    }
-
-    // creating twist rotation relative to tool
-    Eigen::Vector3d twist_rot = axis.normalized() * angle;
-
-    // assigning into full 6dof twist vector
-    twist.head(3) = twist_pos;
-    twist.tail(3) = twist_rot;
-
-    // zeroing all underconstrained cartesian dofs
-    twist = (nullity == 0).select(0,twist);
-  }
+                                          const Eigen::ArrayXi& nullity,Eigen::VectorXd& twist);
 
   /**
    * @brief Convenience function to remove entire rows of the Jacobian matrix.
@@ -432,15 +184,8 @@ namespace kinematics
    * @param indices       An indices vector where each entry indicates an row index of the jacobian that will be kept.
    * @param jacb_reduced  The reduced jacobian containing the only the rows indicated by the 'indices' array.
    */
-  static void reduceJacobian(const Eigen::MatrixXd& jacb,
-                                            const std::vector<int>& indices,Eigen::MatrixXd& jacb_reduced)
-  {
-    jacb_reduced.resize(indices.size(),jacb.cols());
-    for(auto i = 0u; i < indices.size(); i++)
-    {
-      jacb_reduced.row(i) = jacb.row(indices[i]);
-    }
-  }
+  void reduceJacobian(const Eigen::MatrixXd& jacb,
+                                            const std::vector<int>& indices,Eigen::MatrixXd& jacb_reduced);
 
   /**
    * @brief Calculates the damped pseudo inverse of a matrix using singular value decomposition
@@ -449,259 +194,8 @@ namespace kinematics
    * @param eps               Used to threshold the singular values
    * @param lambda            Used in preventing division by small singular values from generating large numbers.
    */
-  static void calculateDampedPseudoInverse(const Eigen::MatrixXd &jacb, Eigen::MatrixXd &jacb_pseudo_inv,
-                                           double eps = 0.011, double lambda = 0.01)
-  {
-    using namespace Eigen;
-
-
-    //Calculate A+ (pseudoinverse of A) = V S+ U*, where U* is Hermition of U (just transpose if all values of U are real)
-    //in order to solve Ax=b -> x*=A+ b
-    Eigen::JacobiSVD<MatrixXd> svd(jacb, Eigen::ComputeThinU | Eigen::ComputeThinV);
-    const MatrixXd &U = svd.matrixU();
-    const VectorXd &Sv = svd.singularValues();
-    const MatrixXd &V = svd.matrixV();
-
-    // calculate the reciprocal of Singular-Values
-    // damp inverse with lambda so that inverse doesn't oscillate near solution
-    size_t nSv = Sv.size();
-    VectorXd inv_Sv(nSv);
-    for(size_t i=0; i< nSv; ++i)
-    {
-      if (fabs(Sv(i)) > eps)
-      {
-        inv_Sv(i) = 1/Sv(i);
-      }
-      else
-      {
-        inv_Sv(i) = Sv(i) / (Sv(i)*Sv(i) + lambda*lambda);
-      }
-    }
-
-    jacb_pseudo_inv = V * inv_Sv.asDiagonal() * U.transpose();
-  }
-
-  /**
-   * @brief Solves the inverse kinematics for a given tool pose using a gradient descent method.  It can handle under constrained DOFs for
-   *  the cartesian tool pose and can also apply a vector onto the null space of the jacobian in order to meet a secondary objective.  It
-   *  also checks for joint limits.
-   * @param robot_state                       A pointer to the robot state.
-   * @param group_name                        The name of the kinematic group. The tool link name is assumed to be the last link in this group.
-   * @param constrained_dofs                  A vector of the form [x y z rx ry rz] filled with 0's and 1's to indicate an unconstrained or fully constrained DOF.
-   * @param joint_update_rates                The weights to be applied to each update during every iteration [num_dimensions x 1].
-   * @param cartesian_convergence_thresholds  The error margin for each dimension of the twist vector [6 x 1].
-   * @param null_proj_weights                 The weights to be multiplied to the null space vector [num_dimension x 1].
-   * @param null_space_vector                 The null space vector which is applied into the jacobian's null space [num_dimension x 1].
-   * @param max_iterations                    The maximum number of iterations that the algorithm will run until convergence is reached.
-   * @param tool_goal_pose                    The desired tool pose.
-   * @param init_joint_pose                   Seed joint pose [num_dimension x 1].
-   * @param joint_pose                        IK joint solution [num_dimension x 1].
-   * @return  True if a solution was found, false otherwise.
-   */
-  static bool solveIK(moveit::core::RobotStatePtr robot_state, const std::string& group_name,
-                      const Eigen::Array<int,6,1>& constrained_dofs,
-                      const Eigen::ArrayXd& joint_update_rates,
-                      const Eigen::Array<double,6,1>& cartesian_convergence_thresholds,
-                      const Eigen::ArrayXd& null_proj_weights,
-                      const Eigen::VectorXd& null_space_vector,
-                      int max_iterations,
-                      const Eigen::Affine3d& tool_goal_pose,
-                      const Eigen::VectorXd& init_joint_pose,
-                      Eigen::VectorXd& joint_pose)
-  {
-
-    using namespace Eigen;
-    using namespace moveit::core;
-
-    // joint variables
-    VectorXd delta_j = VectorXd::Zero(init_joint_pose.size());
-    joint_pose = init_joint_pose;
-    const JointModelGroup* joint_group = robot_state->getJointModelGroup(group_name);
-    robot_state->setJointGroupPositions(joint_group,joint_pose);
-    const auto& joint_names = joint_group->getActiveJointModelNames();
-    std::string tool_link = joint_group->getLinkModelNames().back();
-    Affine3d tool_current_pose = robot_state->getGlobalLinkTransform(tool_link);
-
-    // unwinds revolute joints in order to set them inside its bounds
-    auto unwind_joints = [&joint_group,&joint_names](Eigen::VectorXd& joint_vals) -> bool
-    {
-      if(joint_names.size() != joint_vals.size())
-      {
-        return false;
-      }
-
-      const double incr = 2*M_PI;
-      for(std::size_t i = 0; i < joint_names.size();i++)
-      {
-        auto joint_model = joint_group->getJointModel(joint_names[i]);
-        const JointModel::Bounds& bounds = joint_model->getVariableBounds();
-
-        JointModel::JointType joint_type = joint_model->getType();
-        switch(joint_type)
-        {
-          case JointModel::REVOLUTE:
-          {
-            // checking if it's allowed to rotate indefinitely
-            if(static_cast<const RevoluteJointModel*>(joint_model)->isContinuous())
-            {
-              break;
-            }
-
-            double j = joint_vals(i);
-            for(const VariableBounds& b: bounds)
-            {
-
-             while(j > b.max_position_)
-             {
-               j-= incr;
-             }
-
-             while(j < b.min_position_)
-             {
-               j += incr;
-             }
-            }
-
-            joint_vals(i) = j;
-          }
-          break;
-
-          case JointModel::PRISMATIC:
-          {
-            double j = joint_vals(i);
-            if(!joint_model->satisfiesPositionBounds(&j))
-            {
-              joint_model->enforcePositionBounds(&j);
-              joint_vals(i) = j;
-            }
-          }
-          break;
-
-          default:
-            break;
-        }
-
-      }
-
-      return true;
-    };
-
-    // tool twist variables
-    VectorXd tool_twist, tool_twist_reduced;
-    std::vector<int> indices;
-    for(auto i = 0u; i < constrained_dofs.size(); i++)
-    {
-      if(constrained_dofs(i) != 0)
-      {
-        indices.push_back(i);
-      }
-    }
-    tool_twist_reduced = VectorXd::Zero(indices.size());
-
-    // jacobian calculation variables
-    static MatrixXd jacb_transform(6,6);
-    MatrixXd jacb, jacb_reduced, jacb_pseudo_inv;
-    MatrixXd identity = MatrixXd::Identity(init_joint_pose.size(),init_joint_pose.size());
-    VectorXd null_space_proj;
-    bool project_into_nullspace = (null_proj_weights.size()> 0) &&  (null_proj_weights >1e-8).any();
-
-    unsigned int iteration_count = 0;
-    bool converged = false;
-    while(iteration_count < max_iterations)
-    {
-      iteration_count++;
-
-      // computing twist vector
-      computeTwist(tool_current_pose,tool_goal_pose,constrained_dofs,tool_twist);
-
-      // check convergence
-      if((tool_twist.cwiseAbs().array() <= cartesian_convergence_thresholds).all())
-      {
-        if(robot_state->satisfiesBounds(joint_group))
-        {
-          converged = true;
-          break;
-        }
-      }
-
-      // updating reduced tool twist
-      for(auto i = 0u; i < indices.size(); i++)
-      {
-        tool_twist_reduced(i) = tool_twist(indices[i]);
-      }
-
-      // computing jacobian
-      if(!robot_state->getJacobian(joint_group,robot_state->getLinkModel(tool_link),Vector3d::Zero(),jacb))
-      {
-        ROS_ERROR("Failed to get Jacobian for link %s",tool_link.c_str());
-        return false;
-      }
-
-      // transform jacobian to tool coordinates
-      auto rot = tool_current_pose.inverse().rotation();
-      jacb_transform.setZero();
-      jacb_transform.block(0,0,3,3) = rot;
-      jacb_transform.block(3,3,3,3) = rot;
-      jacb = jacb_transform*jacb;
-
-      // reduce jacobian and compute its pseudo inverse
-      reduceJacobian(jacb,indices,jacb_reduced);
-      calculateDampedPseudoInverse(jacb_reduced,jacb_pseudo_inv,EPSILON,LAMBDA);
-
-      if(project_into_nullspace)
-      {
-        null_space_proj = (identity - jacb_pseudo_inv*jacb_reduced)*null_space_vector;
-        null_space_proj = (null_space_proj.array() * null_proj_weights).matrix();
-
-        // computing joint change
-        delta_j = (jacb_pseudo_inv*tool_twist_reduced) + null_space_proj;
-      }
-      else
-      {
-        // computing joint change
-        delta_j = (jacb_pseudo_inv*tool_twist_reduced);
-      }
-
-      // updating joint values
-      joint_pose += (joint_update_rates* delta_j.array()).matrix();
-      unwind_joints(joint_pose);
-
-      // updating tool pose
-      robot_state->setJointGroupPositions(joint_group,joint_pose);
-      robot_state->updateLinkTransforms();
-      tool_current_pose = robot_state->getGlobalLinkTransform(tool_link);
-    }
-
-    ROS_DEBUG_STREAM_COND(!converged,"IK did not converge, error tool twist "<<tool_twist.transpose());
-
-    return converged;
-  }
-
-  /**
-   * @brief Solves the inverse kinematics for a given tool pose using a gradient descent method.  It can handle under constrained DOFs for
-   *  the cartesian tool pose and can also apply a vector onto the null space of the jacobian in order to meet a secondary objective.  It
-   *  also checks for joint limits.
-   * @param robot_state A pointer to the robot state.
-   * @param group_name  The name of the kinematic group. The tool link name is assumed to be the last link in this group.
-   * @param config      A structure containing the variables to be used in finding a solution.
-   * @param joint_pose  IK joint solution [num_dimension x 1].
-   * @return  True if a solution was found, false otherwise.
-   */
-  static bool solveIK(moveit::core::RobotStatePtr robot_state, const std::string& group_name,const KinematicConfig& config, Eigen::VectorXd& joint_pose)
-  {
-
-    return solveIK(robot_state,
-                   group_name,
-                   config.constrained_dofs,
-                   config.joint_update_rates,
-                   config.cartesian_convergence_thresholds,
-                   config.null_proj_weights,
-                   config.null_space_vector,
-                   config.max_iterations,
-                   config.tool_goal_pose,
-                   config.init_joint_pose,
-                   joint_pose);
-  }
+  void calculateDampedPseudoInverse(const Eigen::MatrixXd &jacb, Eigen::MatrixXd &jacb_pseudo_inv,
+                                           double eps = 0.011, double lambda = 0.01);
 
   /**
    * @brief Convenience function to calculate the Jacobian's null space matrix for an under constrained tool cartesian pose.
@@ -713,82 +207,9 @@ namespace kinematics
    * @param jacb_nullspace    The jacobian null space matrix [num_dimensions x num_dimensions]
    * @return True if a solution was found, false otherwise.
    */
-  static bool computeJacobianNullSpace(moveit::core::RobotStatePtr state,std::string group,std::string tool_link,
+  bool computeJacobianNullSpace(moveit::core::RobotStatePtr state,std::string group,std::string tool_link,
                                        const Eigen::ArrayXi& constrained_dofs,const Eigen::VectorXd& joint_pose,
-                                       Eigen::MatrixXd& jacb_nullspace)
-  {
-    using namespace Eigen;
-    using namespace moveit::core;
-
-    // robot state
-    const JointModelGroup* joint_group = state->getJointModelGroup(group);
-    state->setJointGroupPositions(joint_group,joint_pose);
-    Affine3d tool_pose = state->getGlobalLinkTransform(tool_link);
-
-    // jacobian calculations
-    static MatrixXd jacb_transform(6,6);
-    MatrixXd jacb, jacb_reduced, jacb_pseudo_inv;
-    jacb_transform.setZero();
-
-    if(!state->getJacobian(joint_group,state->getLinkModel(tool_link),Vector3d::Zero(),jacb))
-    {
-      ROS_ERROR("Failed to get Jacobian for link %s",tool_link.c_str());
-      return false;
-    }
-
-    // transform jacobian rotational part to tool coordinates
-    auto rot = tool_pose.inverse().rotation();
-    jacb_transform.setZero();
-    jacb_transform.block(0,0,3,3) = rot;
-    jacb_transform.block(3,3,3,3) = rot;
-    jacb = jacb_transform*jacb;
-
-    // reduce jacobian and compute its pseudo inverse
-    std::vector<int> indices;
-    for(auto i = 0u; i < constrained_dofs.size(); i++)
-    {
-      if(constrained_dofs(i) != 0)
-      {
-        indices.push_back(i);
-      }
-    }
-    reduceJacobian(jacb,indices,jacb_reduced);
-    calculateDampedPseudoInverse(jacb_reduced,jacb_pseudo_inv,EPSILON,LAMBDA);
-
-    int num_joints = joint_pose.size();
-    jacb_nullspace = MatrixXd::Identity(num_joints,num_joints) - jacb_pseudo_inv*jacb_reduced;
-
-    return true;
-  }
-
-  /**
-   * @brief Solves the inverse kinematics for a given tool pose using a gradient descent method.  It can handle under constrained DOFs for
-   *  the cartesian tool pose.
-   * @param robot_state                       A pointer to the robot state.
-   * @param group_name                        The name of the kinematic group. The tool link name is assumed to be the last link in this group.
-   * @param constrained_dofs                  A vector of the form [x y z rx ry rz] filled with 0's and 1's to indicate an unconstrained or fully constrained DOF.
-   * @param joint_update_rates                The weights to be applied to each update during every iteration [num_dimensions x 1].
-   * @param cartesian_convergence_thresholds  The error margin for each dimension of the twist vector [6 x 1].
-   * @param max_iterations                    The maximum number of iterations that the algorithm will run to reach convergence.
-   * @param tool_goal_pose                    The cartesian pose of the tool relative to the world.
-   * @param init_joint_pose                   Seed joint pose [num_dimension x 1].
-   * @param joint_pose                        IK joint solution [num_dimension x 1].
-   * @return  True if a solution was found, false otherwise.
-   * @return
-   */
-  static bool solveIK(moveit::core::RobotStatePtr robot_state, const std::string& group_name, const Eigen::ArrayXi& constrained_dofs,
-               const Eigen::ArrayXd& joint_update_rates,const Eigen::ArrayXd& cartesian_convergence_thresholds, int max_iterations,
-               const Eigen::Affine3d& tool_goal_pose,const Eigen::VectorXd& init_joint_pose,
-               Eigen::VectorXd& joint_pose)
-  {
-    using namespace Eigen;
-    using namespace moveit::core;
-
-    return solveIK(robot_state,group_name,constrained_dofs,joint_update_rates,cartesian_convergence_thresholds,
-            ArrayXd::Zero(joint_update_rates.size()),VectorXd::Zero(joint_update_rates.size()),max_iterations,
-            tool_goal_pose,init_joint_pose,joint_pose);
-  }
-
+                                       Eigen::MatrixXd& jacb_nullspace);
 
 } // kinematics
 } // utils

--- a/stomp_moveit/package.xml
+++ b/stomp_moveit/package.xml
@@ -17,6 +17,8 @@
   <build_depend>stomp_core</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>kdl_parser</build_depend>
+  <build_depend>trac_ik_lib</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
@@ -24,6 +26,8 @@
   <run_depend>stomp_core</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>cmake_modules</run_depend>
+  <run_depend>kdl_parser</run_depend>
+  <run_depend>trac_ik_lib</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/stomp_moveit/src/noise_generators/normal_distribution_sampling.cpp
+++ b/stomp_moveit/src/noise_generators/normal_distribution_sampling.cpp
@@ -167,6 +167,8 @@ bool NormalDistributionSampling::generateNoise(const Eigen::MatrixXd& parameters
   for(auto d = 0u; d < parameters.rows() ; d++)
   {
     rand_generators_[d]->sample(raw_noise_);
+    raw_noise_.head(1).setZero();
+    raw_noise_.tail(1).setZero(); // zeroing out the start and end noise values
     noise.row(d).transpose() = stddev_[d] * raw_noise_;
     parameters_noise.row(d) = parameters.row(d) + noise.row(d);
   }

--- a/stomp_moveit/src/utils/kinematics.cpp
+++ b/stomp_moveit/src/utils/kinematics.cpp
@@ -1,0 +1,439 @@
+/**
+ * @file kinematics.cpp
+ * @brief This defines kinematic related utilities.
+ *
+ * @author Jorge Nicho
+ * @date June 26, 2017
+ * @version TODO
+ * @bug No known bugs
+ *
+ * @copyright Copyright (c) 2016, Southwest Research Institute
+ *
+ * @par License
+ * Software License Agreement (Apache License)
+ * @par
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * @par
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stomp_moveit/utils/kinematics.h>
+#include <kdl_parser/kdl_parser.hpp>
+#include <eigen_conversions/eigen_kdl.h>
+#include <math.h>
+
+static const std::string DEBUG_NS = "stomp_moveit_kinematics";
+
+KDL::JntArray toKDLJntArray(const std::vector<double>& vals)
+{
+  KDL::JntArray jarr(vals.size());
+  for(int i = 0; i < jarr.rows(); i++)
+  {
+    jarr(i) = vals[i];
+  }
+  return std::move(jarr);
+}
+
+KDL::Chain createKDLChain(moveit::core::RobotModelConstPtr robot_model,std::string base_link,std::string tip_link)
+{
+  KDL::Tree tree;
+  KDL::Chain chain;
+  kdl_parser::treeFromUrdfModel(*robot_model->getURDF(),tree);
+  tree.getChain(base_link,tip_link,chain);
+  return chain;
+}
+
+std::shared_ptr<TRAC_IK::TRAC_IK> createTRACIKSolver(moveit::core::RobotModelConstPtr robot_model,const moveit::core::JointModelGroup* group,double max_time = 0.005)
+{
+  using namespace moveit::core;
+
+  std::string base_link = group->getActiveJointModels().front()->getParentLinkModel()->getName();
+  std::string tip_link = group->getLinkModelNames().back();
+  int num_joints = group->getActiveJointModelNames().size();
+
+  ROS_DEBUG_NAMED(DEBUG_NS,"Creating IK solver with base link '%s' and tip link '%s'",base_link.c_str(),tip_link.c_str());
+
+  // create chain
+  KDL::Chain kdl_chain = createKDLChain(robot_model,base_link,tip_link);
+
+  // create joint array limits
+  const JointBoundsVector &bounds = group->getActiveJointModelsBounds();
+  std::vector<double> min_vals, max_vals;
+  for(int i = 0; i < num_joints;i++)
+  {
+    const JointModel::Bounds *jb = bounds[i];
+    for(auto& b: *jb)
+    {
+      max_vals.push_back(b.max_position_);
+      min_vals.push_back(b.min_position_);
+    }
+  }
+
+  // copying to KDL joint arrays
+  num_joints = min_vals.size();
+  KDL::JntArray jmin = toKDLJntArray(min_vals);
+  KDL::JntArray jmax = toKDLJntArray(max_vals);
+  std::shared_ptr<TRAC_IK::TRAC_IK> solver(new TRAC_IK::TRAC_IK(kdl_chain,jmin,jmax,max_time));
+  return solver;
+}
+
+namespace stomp_moveit
+{
+namespace utils
+{
+
+/**
+ * @namespace stomp_moveit::utils::kinematics
+ * @brief Utility functions related to finding Inverse Kinematics solutions
+ */
+namespace kinematics
+{
+
+  IKSolver::IKSolver(moveit::core::RobotModelConstPtr robot_model,std::string group_name,double max_time)
+  {
+    const moveit::core::JointModelGroup* group = robot_model->getJointModelGroup(group_name);
+    ik_solver_impl_ = createTRACIKSolver(robot_model,group,max_time);
+  }
+
+  IKSolver::~IKSolver()
+  {
+
+  }
+
+  bool IKSolver::solve(const Eigen::VectorXd& seed,const Eigen::Affine3d& tool_pose,Eigen::VectorXd& solution,
+             Eigen::VectorXd tol)
+  {
+    using namespace Eigen;
+    std::vector<double> seed_(seed.size(),0);
+    std::vector<double> solution_;
+    std::vector<double> tol_(6,0);
+
+    // converting to eigen
+    VectorXd::Map(&seed_.front(),seed.size()) = seed;
+    VectorXd::Map(&tol_.front(),tol_.size()) = tol;
+
+    if(!solve(seed_,tool_pose,solution_,tol_))
+    {
+      return false;
+    }
+
+    solution.resize(solution_.size());
+    solution = VectorXd::Map(solution_.data(),solution.size());
+    return true;
+  }
+
+  bool IKSolver::solve(const std::vector<double>& seed, const Eigen::Affine3d& tool_pose,std::vector<double>& solution,
+             std::vector<double> tol)
+  {
+    using namespace KDL;
+    using namespace Eigen;
+    JntArray seed_kdl = toKDLJntArray(seed);
+    Twist tol_kdl;
+    JntArray solution_kdl;
+    Frame tool_pose_kdl;
+
+    // converting to KDL data types
+    for(int i = 0; i < tol.size(); i++)
+    {
+      tol_kdl[i] = tol[i];
+    }
+
+    tf::transformEigenToKDL(tool_pose, tool_pose_kdl);
+
+
+    // calling solver
+    if(ik_solver_impl_->CartToJnt(seed_kdl,tool_pose_kdl,solution_kdl,tol_kdl) <= 0)
+    {
+      ROS_DEBUG_STREAM_NAMED(DEBUG_NS,"Failed to solve IK for tool pose:\n"<<tool_pose.matrix());
+      ROS_DEBUG_STREAM_NAMED(DEBUG_NS,"Cartesian tolerance used :\n"<<tol_kdl[0]<<" "<<tol_kdl[1]<<" "<<tol_kdl[2]<<" "<<tol_kdl[3]<<" "<<tol_kdl[4]<<" "<<tol_kdl[5]);
+      return false;
+    }
+
+    solution.resize(solution_kdl.rows());
+    VectorXd::Map(&solution.front(),solution.size()) = solution_kdl.data;
+    return true;
+  }
+
+  bool IKSolver::solve(const std::vector<double>& seed, const moveit_msgs::Constraints& tool_constraints,std::vector<double>& solution)
+  {
+    Eigen::Affine3d tool_pose;
+    std::vector<double> tolerance;
+    if(!decodeCartesianConstraint(tool_constraints,tool_pose,tolerance))
+    {
+      return false;
+    }
+
+    return solve(seed,tool_pose,solution,tolerance);
+  }
+
+  bool IKSolver::solve(const Eigen::VectorXd& seed, const moveit_msgs::Constraints& tool_constraints,Eigen::VectorXd& solution)
+  {
+    Eigen::Affine3d tool_pose;
+    std::vector<double> tolerance;
+    if(!decodeCartesianConstraint(tool_constraints,tool_pose,tolerance))
+    {
+      return false;
+    }
+
+    Eigen::VectorXd tolerance_eigen = Eigen::VectorXd::Zero(6);
+    tolerance_eigen = Eigen::VectorXd::Map(tolerance.data(),tolerance.size());
+    return solve(seed,tool_pose,solution,tolerance_eigen);
+  }
+
+  bool decodeCartesianConstraint(const moveit_msgs::Constraints& constraints, Eigen::Affine3d& tool_pose, Eigen::VectorXd& tolerance)
+  {
+    std::vector<double> tolerance_std;
+    if(!decodeCartesianConstraint(constraints,tool_pose,tolerance_std))
+    {
+      return false;
+    }
+
+    tolerance = Eigen::VectorXd::Map(tolerance_std.data(),tolerance_std.size());
+    return true;
+  }
+
+  bool decodeCartesianConstraint(const moveit_msgs::Constraints& constraints, Eigen::Affine3d& tool_pose, std::vector<double>& tolerance)
+  {
+    using namespace Eigen;
+
+    // declaring result variables
+    tolerance.resize(6,0);
+    geometry_msgs::Point p;
+    Eigen::Quaterniond q = Quaterniond::Identity();
+    const std::vector<moveit_msgs::PositionConstraint>& pos_constraints = constraints.position_constraints;
+    const std::vector<moveit_msgs::OrientationConstraint>& orient_constraints = constraints.orientation_constraints;
+
+    int num_constraints = pos_constraints.size() > orient_constraints.size() ? pos_constraints.size() : orient_constraints.size();
+    if(num_constraints == 0)
+    {
+     ROS_ERROR("Constraints message is empty");
+     return false;
+    }
+
+    // position
+    if(pos_constraints.empty())
+    {
+     ROS_ERROR("Position constraint is empty");
+     return false;
+    }
+    else
+    {
+     const moveit_msgs::PositionConstraint& pos_constraint = pos_constraints[0];
+
+     // tool pose nominal position
+     p = pos_constraint.constraint_region.primitive_poses[0].position;
+
+     // collecting position tolerances
+     const shape_msgs::SolidPrimitive& bv = pos_constraint.constraint_region.primitives[0];
+     bool valid_constraint = true;
+     switch(bv.type)
+     {
+       case shape_msgs::SolidPrimitive::BOX :
+       {
+         if(bv.dimensions.size() != 3)
+         {
+           ROS_WARN("Position constraint for BOX shape incorrectly defined, only 3 dimensions entries are needed");
+           valid_constraint = false;
+           break;
+         }
+
+         using SP = shape_msgs::SolidPrimitive;
+         tolerance[0] = bv.dimensions[SP::BOX_X];
+         tolerance[1] = bv.dimensions[SP::BOX_Y];
+         tolerance[2] = bv.dimensions[SP::BOX_Z];
+       }
+       break;
+
+       case shape_msgs::SolidPrimitive::SPHERE:
+       {
+         if(bv.dimensions.size() != 1)
+         {
+           ROS_WARN("Position constraint for SPHERE shape has no valid dimensions");
+           valid_constraint = false;
+           break;
+         }
+
+         using SP = shape_msgs::SolidPrimitive;
+         tolerance[0] = bv.dimensions[SP::SPHERE_RADIUS];
+         tolerance[1] = bv.dimensions[SP::SPHERE_RADIUS];
+         tolerance[2] = bv.dimensions[SP::SPHERE_RADIUS];
+       }
+       break;
+
+       default:
+
+         ROS_WARN("The Position constraint shape %i isn't supported, defaulting position tolerance to zero",bv.type);
+         break;
+     }
+    }
+
+    // orientation
+    if(orient_constraints.size() == 0)
+    {
+     // setting tolerance to zero
+     std::fill(tolerance.begin()+3,tolerance.end(),M_PI);
+    }
+    else
+    {
+     const moveit_msgs::OrientationConstraint& orient_constraint = orient_constraints[0];
+
+     // collecting orientation tolerance
+     tolerance[3] = orient_constraint.absolute_x_axis_tolerance;
+     tolerance[4] = orient_constraint.absolute_y_axis_tolerance;
+     tolerance[5] = orient_constraint.absolute_z_axis_tolerance;
+
+     // tool pose nominal orientation
+     tf::quaternionMsgToEigen(orient_constraint.orientation,q);
+    }
+
+    // assembling tool pose
+    tool_pose = Affine3d::Identity()*Eigen::Translation3d(Eigen::Vector3d(p.x,p.y,p.z))*q;
+
+    return true;
+  }
+
+  std::vector<Eigen::Affine3d> sampleCartesianPoses(const moveit_msgs::Constraints& c,const std::vector<double> sampling_resolution,int max_samples)
+  {
+    using namespace Eigen;
+
+    std::vector<Eigen::Affine3d> poses;
+
+    // random generator
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    auto sample_val_func = [&gen](double min, double max, double intrv) -> double
+    {
+      double length = max - min;
+      if(length <= intrv || length < 1e-6)
+      {
+        return 0.5*(max + min); // return average
+      }
+
+      int num_intervals = std::ceil(length/intrv);
+      std::uniform_int_distribution<> dis(0, num_intervals);
+      int r = dis(gen);
+      double val = min + r*(intrv);
+      val = val > max ? max : val;
+      return val;
+    };
+
+    // extracting tolerances from constraints
+    const std::vector<moveit_msgs::PositionConstraint>& pos_constraints = c.position_constraints;
+    const std::vector<moveit_msgs::OrientationConstraint>& orient_constraints = c.orientation_constraints;
+    for(std::size_t k = 0; k < pos_constraints.size(); k++)
+    {
+
+      const moveit_msgs::PositionConstraint& pos_constraint = pos_constraints[k];
+      const moveit_msgs::OrientationConstraint& orient_constraint = orient_constraints[k];
+
+      // collecting position tolerances
+      std::vector<double> tolerances(6);
+      const shape_msgs::SolidPrimitive& bv = pos_constraint.constraint_region.primitives[0];
+      bool valid_constraint = true;
+      switch(bv.type)
+      {
+        case shape_msgs::SolidPrimitive::BOX :
+        {
+          if(bv.dimensions.size() != 3)
+          {
+            ROS_WARN("Position constraint for BOX shape incorrectly defined, only 3 dimensions entries are needed");
+            valid_constraint = false;
+            break;
+          }
+
+          using SP = shape_msgs::SolidPrimitive;
+          tolerances[0] = bv.dimensions[SP::BOX_X];
+          tolerances[1] = bv.dimensions[SP::BOX_Y];
+          tolerances[2] = bv.dimensions[SP::BOX_Z];
+        }
+        break;
+
+        case shape_msgs::SolidPrimitive::SPHERE:
+        {
+          if(bv.dimensions.size() != 1)
+          {
+            ROS_WARN("Position constraint for SPHERE shape has no valid dimensions");
+            valid_constraint = false;
+            break;
+          }
+
+          using SP = shape_msgs::SolidPrimitive;
+          tolerances[0] = bv.dimensions[SP::SPHERE_RADIUS];
+          tolerances[1] = bv.dimensions[SP::SPHERE_RADIUS];
+          tolerances[2] = bv.dimensions[SP::SPHERE_RADIUS];
+        }
+        break;
+
+        default:
+
+          ROS_ERROR("The Position constraint shape %i isn't supported",bv.type);
+          valid_constraint = false;
+          break;
+      }
+
+      if(!valid_constraint)
+      {
+        continue;
+      }
+
+      // collecting orientation tolerance
+      tolerances[3] = orient_constraint.absolute_x_axis_tolerance;
+      tolerances[4] = orient_constraint.absolute_y_axis_tolerance;
+      tolerances[5] = orient_constraint.absolute_z_axis_tolerance;
+
+      // calculating total number of samples
+      int total_num_samples = 1;
+      for(std::size_t i = 0; i < tolerances.size(); i++)
+      {
+        total_num_samples *= (std::floor((2*tolerances[i]/sampling_resolution[i]) + 1) );
+      }
+      total_num_samples = total_num_samples > max_samples ? max_samples : total_num_samples;
+
+
+      // tool pose nominal position
+      auto& p = pos_constraint.constraint_region.primitive_poses[0].position;
+
+      // tool pose nominal orientation
+      Eigen::Quaterniond q;
+      tf::quaternionMsgToEigen(orient_constraint.orientation,q);
+
+      // generating samples
+      std::vector<double> vals(6);
+      Affine3d nominal_pos = Affine3d::Identity()*Eigen::Translation3d(Eigen::Vector3d(p.x,p.y,p.z));
+      Affine3d nominal_rot = Affine3d::Identity()*q;
+      for(int i = 0; i < total_num_samples; i++)
+      {
+        for(int j = 0; j < vals.size() ; j++)
+        {
+          vals[j] = sample_val_func(-0.5*tolerances[j],0.5*tolerances[j],sampling_resolution[j]);
+        }
+
+        Affine3d rot = nominal_rot * AngleAxisd(vals[3],Vector3d::UnitX()) * AngleAxisd(vals[4],Vector3d::UnitY())
+            * AngleAxisd(vals[5],Vector3d::UnitZ());
+        Affine3d pose = nominal_pos * Translation3d(Vector3d(vals[0],vals[1],vals[2])) * rot;
+        poses.push_back(pose);
+      }
+
+      if(poses.size()>= max_samples)
+      {
+        break;
+      }
+    }
+
+    return poses;
+  }
+
+} // kinematics
+} // utils
+} // stomp_moveit
+
+
+
+

--- a/stomp_moveit/src/utils/kinematics.cpp
+++ b/stomp_moveit/src/utils/kinematics.cpp
@@ -142,7 +142,7 @@ bool IKSolver::solve(const Eigen::VectorXd& seed,const Eigen::Affine3d& tool_pos
   }
 
   solution.resize(solution_.size());
-  solution = VectorXd::Map(solution_.data(),solution.size());
+  solution = VectorXd::Map(solution_.data(),solution_.size());
   return true;
 }
 
@@ -174,7 +174,7 @@ bool IKSolver::solve(const std::vector<double>& seed, const Eigen::Affine3d& too
   }
 
   solution.resize(solution_kdl.rows());
-  VectorXd::Map(&solution.front(),solution.size()) = solution_kdl.data;
+  VectorXd::Map(&solution[0],solution.size()) = solution_kdl.data;
   return true;
 }
 

--- a/stomp_plugins/example_pages.dox
+++ b/stomp_plugins/example_pages.dox
@@ -15,24 +15,15 @@
 
 /**
 @page tool_goal_pose_example Tool Goal Pose 
-Evaluates the cost of the goal pose by determining how far it is from the underconstrained task manifold.  The parameters
-are as follow:
+Evaluates the cost of the goal pose by determining how far it is from the underconstrained task manifold.  The orientation and position cost range from 
+0 to one.  The tolerance around the tool specified in the motion plan is used to determine the cost. The parameters are as follow:
 @code
   cost_functions:
     - class: stomp_moveit/ToolGoalPose
-      constrained_dofs: [1, 1, 1, 1, 1, 0]
-      position_error_range: [0.01, 0.1]     #[min, max]
-      orientation_error_range: [0.01, 0.1]  #[min, max]
       position_cost_weight: 0.5
       orientation_cost_weight: 0.5
 @endcode
   - class:                    The class name.
-  - constrained_dofs:         Indicates which cartesians DOF are fully constrained (1) or unconstrained (0).  This vector is of the form
-                              [x y z rx ry rz] where each entry can only take a value of 0 or 1.
-  - position_error_range:     Used in scaling the position error from 0 to 1.  Any error less than this range is set to 
-                              a cost of 0 and errors above this range are set to 1.
-  - orientation_error_range:  Used in scaling the orientation error from 0 to 1.  Any error less than this range is set to 
-                              a cost of 0 and errors above this range are set to 1.
   - position_cost_weight:     Factor applied to the position error cost. The total cost = pos_cost * pos_weight + orient_cost * orient_weight
   - orientation_cost_weight:  Factor applied to the orientation error cost.  The total cost = pos_cost * pos_weight + orient_cost * orient_weight
 */
@@ -45,15 +36,9 @@ as follows:
   noise_generator:
     - class: stomp_moveit/GoalGuidedMultivariateGaussian
       stddev: [0.1, 0.05, 0.1, 0.05, 0.05, 0.05, 0.05] 
-      goal_stddev: [0.0, 0.0, 0.0, 0.0, 0.0, 2.0] 
-      constrained_dofs: [1, 1, 1, 1, 1, 0]
 @endcode
   - class:            The class name.
   - stddev:           The amplitude of the noise applied onto each joint.
-  - goal_stddev:      The amplitude of the noise applied onto each cartesian DOF at the goal.  The array has the following
-                      form [px, py, pz, rx, ry, rz].
-  - constrained_dofs: Indicates which cartesians DOF are fully constrained (1) or unconstrained (0).  This vector is of the form
-                      [x y z rx ry rz] where each entry can only take a value of 0 or 1.
 */
 
 /**
@@ -62,15 +47,6 @@ Modifies the trajectory update such that the goal of the updated trajectory is w
 @code
   update_filters:
       - class: stomp_moveit/ConstrainedCartesianGoal
-        constrained_dofs: [1, 1, 1, 1, 1, 0]
-        cartesian_convergence: [0.005, 0.005, 0.005, 0.01, 0.01, 1.00]
-        joint_update_rates: [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-        max_ik_iterations: 100
 @endcode
-  - class:                  The class name.
-  - constrained_dofs:       Indicates which cartesians DOF are fully constrained (1) or unconstrained (0).  This vector is of the form
-                            [x y z rx ry rz] where each entry can only take a value of 0 or 1.
-  - cartesian_convergence:  A vector of convergence values for each cartesian DOF [vx vy vz wx wy wz].
-  - joint_update_rates:     The rates at which to update the joints during numerical ik computations.
-  - max_ik_iterations:      Limit on the number of iterations allowed for numerical ik computations.
+  - class:                  The class name.S
 */

--- a/stomp_plugins/example_pages.dox
+++ b/stomp_plugins/example_pages.dox
@@ -48,5 +48,5 @@ Modifies the trajectory update such that the goal of the updated trajectory is w
   update_filters:
       - class: stomp_moveit/ConstrainedCartesianGoal
 @endcode
-  - class:                  The class name.S
+  - class:                  The class name.
 */

--- a/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
+++ b/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
@@ -30,6 +30,7 @@
 #include <moveit/robot_model/robot_model.h>
 #include <moveit/collision_detection_fcl/collision_world_fcl.h>
 #include <moveit/collision_detection_fcl/collision_robot_fcl.h>
+#include <stomp_moveit/utils/kinematics.h>
 #include "stomp_moveit/cost_functions/stomp_cost_function.h"
 
 namespace stomp_moveit
@@ -131,6 +132,7 @@ protected:
   std::string tool_link_;
   moveit::core::RobotModelConstPtr robot_model_;
   moveit::core::RobotStatePtr state_;
+  stomp_moveit::utils::kinematics::IKSolverPtr ik_solver_;
 
   // planning context information
   planning_scene::PlanningSceneConstPtr planning_scene_;
@@ -138,18 +140,19 @@ protected:
 
   // goal pose
   Eigen::Affine3d tool_goal_pose_;                    /**< @brief The desired goal pose for the active plan request **/
+  Eigen::VectorXd tool_goal_tolerance_;
+  Eigen::VectorXd min_twist_error_;
+  Eigen::VectorXd max_twist_error_;
 
   // ros parameters
-  Eigen::ArrayXi dof_nullity_;                        /**< @brief Indicates which cartesian DOF's are unconstrained (0) and fully constrained (1)*/
-  std::pair<double,double> position_error_range_;     /**< @brief The allowed position error range, [2 x 1] */
-  std::pair<double,double> orientation_error_range_;  /**< @brief The allowed orientation error range as euler angles, [2 x 1] **/
   double position_cost_weight_;                       /**< @brief factor multiplied to the scaled position error **/
   double orientation_cost_weight_;                    /**< @brief factor multiplied to the scaled orientation error **/
 
-  // support variables
+  // partial results variables
   Eigen::VectorXd last_joint_pose_;
   Eigen::Affine3d last_tool_pose_;
   Eigen::VectorXd tool_twist_error_;
+
 
 
 };

--- a/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
+++ b/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
@@ -132,7 +132,6 @@ protected:
   std::string tool_link_;
   moveit::core::RobotModelConstPtr robot_model_;
   moveit::core::RobotStatePtr state_;
-  stomp_moveit::utils::kinematics::IKSolverPtr ik_solver_;
 
   // planning context information
   planning_scene::PlanningSceneConstPtr planning_scene_;

--- a/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
+++ b/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
@@ -121,7 +121,7 @@ public:
    * @param final_cost        The cost value after optimizing.
    * @param parameters        The parameters generated at the end of current iteration[num_dimensions x num_timesteps]
    */
-  virtual void done(bool success,int total_iterations,double final_cost,const Eigen::MatrixXd& parameters) override{}
+  virtual void done(bool success,int total_iterations,double final_cost,const Eigen::MatrixXd& parameters) override;
 
 protected:
 

--- a/stomp_plugins/include/stomp_plugins/noise_generators/goal_guided_multivariate_gaussian.h
+++ b/stomp_plugins/include/stomp_plugins/noise_generators/goal_guided_multivariate_gaussian.h
@@ -127,17 +127,23 @@ public:
 
 protected:
 
-  virtual bool setNoiseGeneration(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  virtual bool setupNoiseGeneration(const planning_scene::PlanningSceneConstPtr& planning_scene,
                    const moveit_msgs::MotionPlanRequest &req,
                    const stomp_core::StompConfiguration &config,
                    moveit_msgs::MoveItErrorCodes& error_code);
 
-  virtual bool setGoalConstraints(const planning_scene::PlanningSceneConstPtr& planning_scene,
+  virtual bool setupGoalConstraints(const planning_scene::PlanningSceneConstPtr& planning_scene,
                    const moveit_msgs::MotionPlanRequest &req,
                    const stomp_core::StompConfiguration &config,
                    moveit_msgs::MoveItErrorCodes& error_code);
 
-  virtual bool generateRandomGoal(const Eigen::VectorXd& seed,Eigen::VectorXd& goal_joint_pose);
+  /**
+   * @brief Genereates a random tool pose by apply noise on the redundant axis to a reference tool pose;
+   * @param reference_joint_pose  Joint position used in computing the reference tool pose with FK
+   * @param goal_joint_pose       The joint position corresponding to the randomized tool pose
+   * @return  True if succeded, false otherwise
+   */
+  virtual bool generateRandomGoal(const Eigen::VectorXd& reference_joint_pose,Eigen::VectorXd& goal_joint_pose);
 
 protected:
 
@@ -145,17 +151,16 @@ protected:
   std::string name_;
   std::string group_;
 
-  // goal tool constraints
+  // goal constraints
   std::string tool_link_;
+  Eigen::VectorXd tool_goal_tolerance_;
 
   // ros parameters
-  utils::kinematics::KinematicConfig kc_;                             /**< @brief The kinematic configuration to find valid goal poses **/
+  std::vector<double> stddev_;                                        /**< @brief The standard deviations applied to each joint, [num_dimensions x 1 **/
 
   // noisy trajectory generation
   std::vector<utils::MultivariateGaussianPtr> traj_noise_generators_; /**< @brief Randomized numerical distribution generators, [6 x 1] **/
   Eigen::VectorXd raw_noise_;                                         /**< @brief The noise vector **/
-  std::vector<double> stddev_;                                        /**< @brief The standard deviations applied to each joint, [num_dimensions x 1 **/
-  std::vector<double> goal_stddev_;                                   /**< @brief The standard deviations applied to each cartesian dimension at the goal, [6 x 1] **/
 
   // random goal generation
   boost::shared_ptr<RandomGenerator> goal_rand_generator_;            /**< @brief Random generator for the tool goal pose **/
@@ -163,6 +168,7 @@ protected:
   // robot
   moveit::core::RobotModelConstPtr robot_model_;
   moveit::core::RobotStatePtr state_;
+  stomp_moveit::utils::kinematics::IKSolverPtr ik_solver_;
 
 };
 

--- a/stomp_plugins/include/stomp_plugins/update_filters/constrained_cartesian_goal.h
+++ b/stomp_plugins/include/stomp_plugins/update_filters/constrained_cartesian_goal.h
@@ -113,11 +113,16 @@ protected:
   std::string group_name_;
 
   // kinematics
-  utils::kinematics::KinematicConfig kc_;
+  //utils::kinematics::KinematicConfig kc_;
+
+  // goal config
+  Eigen::Affine3d tool_goal_pose_;                    /**< @brief The desired goal pose for the active plan request **/
+  Eigen::VectorXd tool_goal_tolerance_;
 
   // robot
   moveit::core::RobotModelConstPtr robot_model_;
   moveit::core::RobotStatePtr state_;
+  stomp_moveit::utils::kinematics::IKSolverPtr ik_solver_;
   std::string tool_link_;
 };
 

--- a/stomp_plugins/src/cost_functions/tool_goal_pose.cpp
+++ b/stomp_plugins/src/cost_functions/tool_goal_pose.cpp
@@ -121,15 +121,15 @@ bool ToolGoalPose::setMotionPlanRequest(const planning_scene::PlanningSceneConst
       state_->updateLinkTransforms();
       Eigen::Affine3d start_tool_pose = state_->getGlobalLinkTransform(tool_link_);
       moveit_msgs::Constraints cartesian_constraints = utils::kinematics::constructCartesianConstraints(g,start_tool_pose);
-      std::vector<double> tolerance;
-      found_goal = utils::kinematics::decodeCartesianConstraint(cartesian_constraints,tool_goal_pose_,tolerance);
+      found_goal = utils::kinematics::decodeCartesianConstraint(cartesian_constraints,tool_goal_pose_,tool_goal_tolerance_);
+      ROS_DEBUG_STREAM("ToolGoalTolerance cost function will use tolerance: "<<tool_goal_tolerance_.transpose());
       break;
     }
 
 
     if(!found_goal)
     {
-      ROS_WARN("%s a cartesian goal pose in MotionPlanRequest was not provided,calculating it from FK",getName().c_str());
+      ROS_DEBUG("%s a cartesian goal pose in MotionPlanRequest was not provided,calculating it from FK",getName().c_str());
 
       // check joint constraints
       if(g.joint_constraints.empty())
@@ -162,9 +162,9 @@ bool ToolGoalPose::setMotionPlanRequest(const planning_scene::PlanningSceneConst
 
   // setting cartesian error range
   min_twist_error_ = tool_goal_tolerance_;
+  max_twist_error_.resize(min_twist_error_.size());
   max_twist_error_.head(3) = min_twist_error_.head(3)*POS_MAX_ERROR_RATIO;
   max_twist_error_.tail(3) = min_twist_error_.tail(3)*ROT_MAX_ERROR_RATIO;
-  max_twist_error_.tail(3) = (max_twist_error_.tail(3).array() > M_PI).select(M_PI,max_twist_error_.tail(3));
 
   return true;
 }

--- a/stomp_plugins/src/cost_functions/tool_goal_pose.cpp
+++ b/stomp_plugins/src/cost_functions/tool_goal_pose.cpp
@@ -114,15 +114,18 @@ bool ToolGoalPose::setMotionPlanRequest(const planning_scene::PlanningSceneConst
   for(const auto& g: goals)
   {
 
-    if(utils::kinematics::validateCartesianConstraints(g))
+    if(utils::kinematics::isCartesianConstraints(g))
     {
       // tool cartesian goal data
       state_->updateLinkTransforms();
       Eigen::Affine3d start_tool_pose = state_->getGlobalLinkTransform(tool_link_);
-      moveit_msgs::Constraints cartesian_constraints = utils::kinematics::constructCartesianConstraints(g,start_tool_pose);
-      found_goal = utils::kinematics::decodeCartesianConstraint(robot_model_,cartesian_constraints,tool_goal_pose_,
-                                                                tool_goal_tolerance_,robot_model_->getRootLinkName());
-      ROS_DEBUG_STREAM("ToolGoalTolerance cost function will use tolerance: "<<tool_goal_tolerance_.transpose());
+      boost::optional<moveit_msgs::Constraints> cartesian_constraints = utils::kinematics::curateCartesianConstraints(g,start_tool_pose);
+      if(cartesian_constraints.is_initialized())
+      {
+        found_goal = utils::kinematics::decodeCartesianConstraint(robot_model_,cartesian_constraints.get(),tool_goal_pose_,
+                                                                  tool_goal_tolerance_,robot_model_->getRootLinkName());
+        ROS_DEBUG_STREAM("ToolGoalTolerance cost function will use tolerance: "<<tool_goal_tolerance_.transpose());
+      }
       break;
     }
 

--- a/stomp_plugins/src/noise_generators/goal_guided_multivariate_gaussian.cpp
+++ b/stomp_plugins/src/noise_generators/goal_guided_multivariate_gaussian.cpp
@@ -208,14 +208,18 @@ bool GoalGuidedMultivariateGaussian::setupGoalConstraints(const planning_scene::
   for(const auto& g: goals)
   {
 
-    if(utils::kinematics::validateCartesianConstraints(g))
+    if(utils::kinematics::isCartesianConstraints(g))
     {
       // decoding goal
       state_->updateLinkTransforms();
       Eigen::Affine3d start_tool_pose = state_->getGlobalLinkTransform(tool_link_);
-      moveit_msgs::Constraints cartesian_constraints = utils::kinematics::constructCartesianConstraints(g,start_tool_pose);
-      Eigen::Affine3d tool_goal_pose;
-      found_valid = utils::kinematics::decodeCartesianConstraint(robot_model_,cartesian_constraints,tool_goal_pose,tool_goal_tolerance_,robot_model_->getRootLinkName());
+      boost::optional<moveit_msgs::Constraints> cartesian_constraints = utils::kinematics::curateCartesianConstraints(g,start_tool_pose);
+      if(cartesian_constraints.is_initialized())
+      {
+        Eigen::Affine3d tool_goal_pose;
+        found_valid = utils::kinematics::decodeCartesianConstraint(robot_model_,cartesian_constraints.get(),
+                                                                   tool_goal_pose,tool_goal_tolerance_,robot_model_->getRootLinkName());
+      }
     }
 
 

--- a/stomp_plugins/src/noise_generators/goal_guided_multivariate_gaussian.cpp
+++ b/stomp_plugins/src/noise_generators/goal_guided_multivariate_gaussian.cpp
@@ -207,7 +207,6 @@ bool GoalGuidedMultivariateGaussian::setupGoalConstraints(const planning_scene::
   bool found_valid = false;
   for(const auto& g: goals)
   {
-
     if(utils::kinematics::isCartesianConstraints(g))
     {
       // decoding goal
@@ -222,22 +221,24 @@ bool GoalGuidedMultivariateGaussian::setupGoalConstraints(const planning_scene::
       }
     }
 
-
-    if(!found_valid)
+    if(found_valid)
     {
-      ROS_DEBUG("%s a cartesian goal pose in MotionPlanRequest was not provided,using default cartesian tolerance",getName().c_str());
-
-      // creating default cartesian tolerance
-      tool_goal_tolerance_.resize(CARTESIAN_DOF_SIZE);
-      double ptol = DEFAULT_POS_TOLERANCE;
-      double rtol = DEFAULT_ROT_TOLERANCE;
-      tool_goal_tolerance_ << ptol, ptol, ptol, rtol, rtol, rtol;
+      ROS_DEBUG_STREAM(getName()<< " using tool tolerances of "<< tool_goal_tolerance_.transpose());
+      break;
     }
-
-    break;
   }
 
-  ROS_DEBUG("%s using '%s' tool link",getName().c_str(),tool_link_.c_str());
+  if(!found_valid)
+  {
+    ROS_DEBUG("%s a cartesian goal pose in MotionPlanRequest was not provided,using default cartesian tolerance",getName().c_str());
+
+    // creating default cartesian tolerance
+    tool_goal_tolerance_.resize(CARTESIAN_DOF_SIZE);
+    double ptol = DEFAULT_POS_TOLERANCE;
+    double rtol = DEFAULT_ROT_TOLERANCE;
+    tool_goal_tolerance_ << ptol, ptol, ptol, rtol, rtol, rtol;
+  }
+
   error_code.val = error_code.SUCCESS;
 
   return true;

--- a/stomp_plugins/src/update_filters/constrained_cartesian_goal.cpp
+++ b/stomp_plugins/src/update_filters/constrained_cartesian_goal.cpp
@@ -87,6 +87,9 @@ bool ConstrainedCartesianGoal::setMotionPlanRequest(const planning_scene::Planni
   state_.reset(new RobotState(robot_model_));
   robotStateMsgToRobotState(req.start_state,*state_);
 
+  // update kinematic model
+  ik_solver_->setKinematicState(*state_);
+
   const std::vector<moveit_msgs::Constraints>& goals = req.goal_constraints;
   if(goals.empty())
   {
@@ -106,7 +109,8 @@ bool ConstrainedCartesianGoal::setMotionPlanRequest(const planning_scene::Planni
       state_->updateLinkTransforms();
       Eigen::Affine3d start_tool_pose = state_->getGlobalLinkTransform(tool_link_);
       moveit_msgs::Constraints cartesian_constraints = utils::kinematics::constructCartesianConstraints(g,start_tool_pose);
-      found_goal = utils::kinematics::decodeCartesianConstraint(cartesian_constraints,tool_goal_pose_,tool_goal_tolerance_);
+      found_goal = utils::kinematics::decodeCartesianConstraint(robot_model_,cartesian_constraints,tool_goal_pose_,tool_goal_tolerance_,
+                                                                robot_model_->getRootLinkName());
       break;
     }
 

--- a/stomp_plugins/src/update_filters/constrained_cartesian_goal.cpp
+++ b/stomp_plugins/src/update_filters/constrained_cartesian_goal.cpp
@@ -103,14 +103,17 @@ bool ConstrainedCartesianGoal::setMotionPlanRequest(const planning_scene::Planni
   for(const auto& g: goals)
   {
 
-    if(utils::kinematics::validateCartesianConstraints(g))
+    if(utils::kinematics::isCartesianConstraints(g))
     {
       // tool cartesian goal data
       state_->updateLinkTransforms();
       Eigen::Affine3d start_tool_pose = state_->getGlobalLinkTransform(tool_link_);
-      moveit_msgs::Constraints cartesian_constraints = utils::kinematics::constructCartesianConstraints(g,start_tool_pose);
-      found_goal = utils::kinematics::decodeCartesianConstraint(robot_model_,cartesian_constraints,tool_goal_pose_,tool_goal_tolerance_,
-                                                                robot_model_->getRootLinkName());
+      boost::optional<moveit_msgs::Constraints> cartesian_constraints = utils::kinematics::curateCartesianConstraints(g,start_tool_pose);
+      if(cartesian_constraints.is_initialized())
+      {
+        found_goal = utils::kinematics::decodeCartesianConstraint(robot_model_,cartesian_constraints.get(),tool_goal_pose_,tool_goal_tolerance_,
+                                                                  robot_model_->getRootLinkName());
+      }
       break;
     }
 

--- a/stomp_plugins/src/update_filters/constrained_cartesian_goal.cpp
+++ b/stomp_plugins/src/update_filters/constrained_cartesian_goal.cpp
@@ -37,8 +37,8 @@
 PLUGINLIB_EXPORT_CLASS(stomp_moveit::update_filters::ConstrainedCartesianGoal,stomp_moveit::update_filters::StompUpdateFilter);
 
 static int CARTESIAN_DOF_SIZE = 6;
-static int const IK_ATTEMPTS = 10;
-static int const IK_TIMEOUT = 0.05;
+static const double DEFAULT_POS_TOLERANCE = 0.001;
+static const double DEFAULT_ROT_TOLERANCE = 0.01;
 
 namespace stomp_moveit
 {
@@ -48,13 +48,12 @@ namespace update_filters
 ConstrainedCartesianGoal::ConstrainedCartesianGoal():
     name_("ConstrainedCartesianGoal")
 {
-  // TODO Auto-generated constructor stub
 
 }
 
 ConstrainedCartesianGoal::~ConstrainedCartesianGoal()
 {
-  // TODO Auto-generated destructor stub
+
 }
 
 bool ConstrainedCartesianGoal::initialize(moveit::core::RobotModelConstPtr robot_model_ptr,
@@ -62,6 +61,7 @@ bool ConstrainedCartesianGoal::initialize(moveit::core::RobotModelConstPtr robot
 {
   group_name_ = group_name;
   robot_model_ = robot_model_ptr;
+  ik_solver_.reset(new stomp_moveit::utils::kinematics::IKSolver(robot_model_ptr,group_name));
 
   return configure(config);
 }
@@ -69,49 +69,6 @@ bool ConstrainedCartesianGoal::initialize(moveit::core::RobotModelConstPtr robot
 bool ConstrainedCartesianGoal::configure(const XmlRpc::XmlRpcValue& config)
 {
   using namespace XmlRpc;
-
-  try
-  {
-    XmlRpcValue params = config;
-
-    XmlRpcValue dof_nullity_param = params["constrained_dofs"];
-    XmlRpcValue dof_thresholds_param = params["cartesian_convergence"];
-    XmlRpcValue joint_updates_param = params["joint_update_rates"];
-    if((dof_nullity_param.getType() != XmlRpcValue::TypeArray) ||
-        dof_nullity_param.size() < CARTESIAN_DOF_SIZE ||
-        dof_thresholds_param.getType() != XmlRpcValue::TypeArray ||
-        dof_thresholds_param.size() < CARTESIAN_DOF_SIZE  ||
-        joint_updates_param.getType() != XmlRpcValue::TypeArray ||
-        joint_updates_param.size() == 0)
-    {
-      ROS_ERROR("UnderconstrainedGoal received invalid array parameters");
-      return false;
-    }
-
-    for(auto i = 0u; i < dof_nullity_param.size(); i++)
-    {
-      kc_.constrained_dofs(i) = static_cast<int>(dof_nullity_param[i]);
-    }
-
-    for(auto i = 0u; i < dof_thresholds_param.size(); i++)
-    {
-      kc_.cartesian_convergence_thresholds(i) = static_cast<double>(dof_thresholds_param[i]);
-    }
-
-    kc_.joint_update_rates.resize(joint_updates_param.size());
-    for(auto i = 0u; i < joint_updates_param.size(); i++)
-    {
-      kc_.joint_update_rates(i) = static_cast<double>(joint_updates_param[i]);
-    }
-
-    kc_.max_iterations = static_cast<int>(params["max_ik_iterations"]);
-  }
-  catch(XmlRpc::XmlRpcException& e)
-  {
-    ROS_ERROR("%s failed to load parameters, %s",getName().c_str(),e.getMessage().c_str());
-    return false;
-  }
-
   return true;
 }
 
@@ -140,41 +97,34 @@ bool ConstrainedCartesianGoal::setMotionPlanRequest(const planning_scene::Planni
 
   // storing tool goal pose
   bool found_goal = false;
-  state_->updateCollisionBodyTransforms();
-  Eigen::Affine3d start_tool_pose = state_->getGlobalLinkTransform(tool_link_);
-  for(const auto& cg: goals)
+  for(const auto& g: goals)
   {
-    if(validateCartesianConstraints(cg)) // check cartesian pose constraints first
+
+    if(utils::kinematics::validateCartesianConstraints(g))
     {
-      auto g = constructCartesianConstraints(cg,start_tool_pose);
-
-      // storing cartesian goal pose using ik
-      const moveit_msgs::PositionConstraint& pos_constraint = g.position_constraints.front();
-      const moveit_msgs::OrientationConstraint& orient_constraint = g.orientation_constraints.front();
-
-      KinematicConfig kc;
-      Eigen::VectorXd joint_pose;
-      if(createKinematicConfig(joint_group,pos_constraint,orient_constraint,req.start_state,kc))
-      {
-        kc_.tool_goal_pose = kc.tool_goal_pose;
-        found_goal = true;
-        break;
-      }
+      // tool cartesian goal data
+      state_->updateLinkTransforms();
+      Eigen::Affine3d start_tool_pose = state_->getGlobalLinkTransform(tool_link_);
+      moveit_msgs::Constraints cartesian_constraints = utils::kinematics::constructCartesianConstraints(g,start_tool_pose);
+      found_goal = utils::kinematics::decodeCartesianConstraint(cartesian_constraints,tool_goal_pose_,tool_goal_tolerance_);
+      break;
     }
 
-    if(!found_goal )
+
+    if(!found_goal)
     {
+      ROS_DEBUG("%s a cartesian goal pose in MotionPlanRequest was not provided,calculating it from FK",getName().c_str());
+
       // check joint constraints
-      if(cg.joint_constraints.empty())
+      if(g.joint_constraints.empty())
       {
-        ROS_WARN_STREAM("No joint values for the goal were found");
-        continue;
+        ROS_ERROR_STREAM("No joint values for the goal were found");
+        error_code.val = error_code.INVALID_GOAL_CONSTRAINTS;
+        return false;
       }
 
-      ROS_WARN("%s a cartesian goal pose in MotionPlanRequest was not provided,calculating it from FK",getName().c_str());
-
-      // compute FK to obtain cartesian goal pose
-      const std::vector<moveit_msgs::JointConstraint>& joint_constraints = cg.joint_constraints;
+      // compute FK to obtain tool pose
+      const std::vector<moveit_msgs::JointConstraint>& joint_constraints = g.joint_constraints;
 
       // copying goal values into state
       for(auto& jc: joint_constraints)
@@ -182,12 +132,15 @@ bool ConstrainedCartesianGoal::setMotionPlanRequest(const planning_scene::Planni
         state_->setVariablePosition(jc.joint_name,jc.position);
       }
 
-      // storing reference goal position tool and pose
+      // storing tool goal pose and tolerance
       state_->update(true);
-      kc_.tool_goal_pose = state_->getGlobalLinkTransform(tool_link_);
+      tool_goal_pose_ = state_->getGlobalLinkTransform(tool_link_);
+      tool_goal_tolerance_.resize(CARTESIAN_DOF_SIZE);
+      double ptol = DEFAULT_POS_TOLERANCE;
+      double rtol = DEFAULT_ROT_TOLERANCE;
+      tool_goal_tolerance_ << ptol, ptol, ptol, rtol, rtol, rtol;
       found_goal = true;
       break;
-
     }
   }
 
@@ -215,32 +168,21 @@ bool ConstrainedCartesianGoal::filter(std::size_t start_timestep,
 
 
   filtered = false;
-  kc_.init_joint_pose = parameters.rightCols(1);
-  VectorXd joint_pose;
-  MatrixXd jacb_nullspace;
+  VectorXd goal_joint_pose;
+  VectorXd seed = parameters.rightCols(1) + updates.rightCols(1);
 
-  // projecting update into nullspace
-  if(kinematics::computeJacobianNullSpace(state_,group_name_,tool_link_,kc_.constrained_dofs,kc_.init_joint_pose,jacb_nullspace))
-  {
-    kc_.init_joint_pose  += jacb_nullspace*(updates.rightCols(1));
-  }
-  else
-  {
-    ROS_WARN("%s failed to project into the nullspace of the jacobian",getName().c_str());
-  }
-
-  if(kinematics::solveIK(state_,group_name_,kc_,joint_pose))
+  // solve kinematics
+  if(ik_solver_->solve(seed,tool_goal_pose_,goal_joint_pose,tool_goal_tolerance_))
   {
     filtered = true;
-    updates.rightCols(1) = joint_pose - parameters.rightCols(1);
+    updates.rightCols(1) = goal_joint_pose - parameters.rightCols(1);
   }
   else
   {
-    ROS_DEBUG("%s failed to update under-constrained tool goal pose due to ik error",getName().c_str());
+    ROS_DEBUG("%s failed failed to solve ik using noisy goal pose as seed, zeroing updates",getName().c_str());
     filtered = true;
     updates.rightCols(1) = Eigen::VectorXd::Zero(updates.rows());
   }
-
 
   return true;
 }

--- a/stomp_test_kr210_moveit_config/config/stomp_config.yaml
+++ b/stomp_test_kr210_moveit_config/config/stomp_config.yaml
@@ -109,33 +109,30 @@ stomp/manipulator_tool:
     control_cost_weight: 0.0
   task:
     noise_generator:
-      - class: stomp_moveit/NormalDistributionSampling
-        stddev: [0.05, 0.4, 1.2, 0.4, 0.4, 0.1, 0.1]
+      - class: stomp_moveit/GoalGuidedMultivariateGaussian
+        stddev: [0.05, 0.4, 1.2, 0.4, 0.4, 0.1, 0.1] 
+#      - class: stomp_moveit/NormalDistributionSampling
+#        stddev: [0.05, 0.4, 1.2, 0.4, 0.4, 0.1, 0.1]
     cost_functions:
       - class: stomp_moveit/CollisionCheck 
         kernel_window_percentage: 0.2
         collision_penalty: 1.0
         cost_weight: 1.0
         longest_valid_joint_move: 0.05 
-#      - class: stomp_moveit/ObstacleDistanceGradient
-#        max_distance: 0.2
-#        cost_weight: 1.0
-#        longest_valid_joint_move: 0.05 
+      - class: stomp_moveit/ToolGoalPose
+        position_cost_weight: 0.5
+        orientation_cost_weight: 0.5
     noisy_filters:
       - class: stomp_moveit/JointLimits
         lock_start: True
         lock_goal: False
       - class: stomp_moveit/MultiTrajectoryVisualization
         line_width: 0.04
-        rgb: [255, 255, 0]
+        rgb: [255, 200, 0]
         marker_array_topic: stomp_trajectories
         marker_namespace: noisy
     update_filters:
       - class: stomp_moveit/ConstrainedCartesianGoal
-        constrained_dofs: [1, 1, 1, 1, 1, 1]
-        cartesian_convergence: [0.005, 0.005, 0.005, 0.01, 0.01, 0.01]
-        joint_update_rates: [0.01 , 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-        max_ik_iterations: 100
       - class: stomp_moveit/PolynomialSmoother
         poly_order: 5
       - class: stomp_moveit/TrajectoryVisualization

--- a/stomp_test_kr210_moveit_config/config/stomp_config.yaml
+++ b/stomp_test_kr210_moveit_config/config/stomp_config.yaml
@@ -4,24 +4,23 @@ stomp/manipulator:
     num_timesteps: 50
     num_iterations: 50
     num_iterations_after_valid: 0    
-    num_rollouts: 10
-    max_rollouts: 100
+    num_rollouts: 40
+    max_rollouts: 40
     initialization_method: 1 #[1 : LINEAR_INTERPOLATION, 2 : CUBIC_POLYNOMIAL, 3 : MININUM_CONTROL_COST
     control_cost_weight: 0.0
   task:
     noise_generator:
-      - class: stomp_moveit/NormalDistributionSampling
-        stddev: [0.1, 1.0, 1.0, 0.4, 0.3, 0.3]
+      - class: stomp_moveit/GoalGuidedMultivariateGaussian
+        stddev: [0.8, 1.0, 1.0, 0.4, 0.3, 0.3]
     cost_functions:
       - class: stomp_moveit/CollisionCheck
         collision_penalty: 1.0
         cost_weight: 1.0
         kernel_window_percentage: 0.2
         longest_valid_joint_move: 0.05 
-#      - class: stomp_moveit/ObstacleDistanceGradient
-#        max_distance: 0.2
-#        cost_weight: 1.0
-#        longest_valid_joint_move: 0.05 
+      - class: stomp_moveit/ToolGoalPose
+        position_cost_weight: 0.5
+        orientation_cost_weight: 0.5
     noisy_filters:
       - class: stomp_moveit/JointLimits
         lock_start: True
@@ -33,10 +32,6 @@ stomp/manipulator:
         marker_namespace: noisy
     update_filters:
       - class: stomp_moveit/ConstrainedCartesianGoal
-        constrained_dofs: [1, 1, 1, 1, 1, 1]
-        cartesian_convergence: [0.005, 0.005, 0.005, 0.01, 0.01, 0.01]
-        joint_update_rates: [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-        max_ik_iterations: 100
       - class: stomp_moveit/PolynomialSmoother
         poly_order: 5
       - class: stomp_moveit/TrajectoryVisualization
@@ -58,7 +53,7 @@ stomp/manipulator_rail:
     control_cost_weight: 0.0
   task:
     noise_generator:
-      - class: stomp_moveit/NormalDistributionSampling
+      - class: stomp_moveit/GoalGuidedMultivariateGaussian
         stddev: [0.05, 0.4, 1.2, 0.4, 0.4, 0.1, 0.1]
     cost_functions:
       - class: stomp_moveit/CollisionCheck
@@ -66,6 +61,9 @@ stomp/manipulator_rail:
         cost_weight: 1.0
         kernel_window_percentage: 0.2
         longest_valid_joint_move: 0.05 
+      - class: stomp_moveit/ToolGoalPose
+        position_cost_weight: 0.5
+        orientation_cost_weight: 0.5
     noisy_filters:
       - class: stomp_moveit/JointLimits
         lock_start: True
@@ -77,19 +75,13 @@ stomp/manipulator_rail:
         marker_namespace: noisy
     update_filters:
       - class: stomp_moveit/ConstrainedCartesianGoal
-        constrained_dofs: [1, 1, 1, 1, 1, 1]
-        cartesian_convergence: [0.005, 0.005, 0.005, 0.01, 0.01, 0.01]
-        joint_update_rates: [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-        max_ik_iterations: 100
-      - class: stomp_moveit/UpdateLogger
-        package: stomp_moveit
-        directory: log
-        filename: noisy_update.txt
-      - class: stomp_moveit/ControlCostProjectionMatrix
-      - class: stomp_moveit/UpdateLogger
-        package: stomp_moveit
-        directory: log
-        filename: smoothed_update.txt
+      - class: stomp_moveit/PolynomialSmoother
+        poly_order: 5
+#      - class: stomp_moveit/ControlCostProjectionMatrix
+#      - class: stomp_moveit/UpdateLogger
+#        package: stomp_moveit
+#        directory: log
+#        filename: smoothed_update.txt
       - class: stomp_moveit/TrajectoryVisualization
         line_width: 0.05
         rgb: [0, 191, 255]
@@ -111,8 +103,6 @@ stomp/manipulator_tool:
     noise_generator:
       - class: stomp_moveit/GoalGuidedMultivariateGaussian
         stddev: [0.05, 0.4, 1.2, 0.4, 0.4, 0.1, 0.1] 
-#      - class: stomp_moveit/NormalDistributionSampling
-#        stddev: [0.05, 0.4, 1.2, 0.4, 0.4, 0.1, 0.1]
     cost_functions:
       - class: stomp_moveit/CollisionCheck 
         kernel_window_percentage: 0.2

--- a/stomp_test_kr210_moveit_config/config/stomp_config.yaml
+++ b/stomp_test_kr210_moveit_config/config/stomp_config.yaml
@@ -25,13 +25,18 @@ stomp/manipulator:
     noisy_filters:
       - class: stomp_moveit/JointLimits
         lock_start: True
-        lock_goal: True
+        lock_goal: False
       - class: stomp_moveit/MultiTrajectoryVisualization
         line_width: 0.02
         rgb: [0, 255, 0]
         marker_array_topic: stomp_trajectories
         marker_namespace: noisy
     update_filters:
+      - class: stomp_moveit/ConstrainedCartesianGoal
+        constrained_dofs: [1, 1, 1, 1, 1, 1]
+        cartesian_convergence: [0.005, 0.005, 0.005, 0.01, 0.01, 0.01]
+        joint_update_rates: [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+        max_ik_iterations: 100
       - class: stomp_moveit/PolynomialSmoother
         poly_order: 5
       - class: stomp_moveit/TrajectoryVisualization
@@ -64,13 +69,18 @@ stomp/manipulator_rail:
     noisy_filters:
       - class: stomp_moveit/JointLimits
         lock_start: True
-        lock_goal: True
+        lock_goal: False
       - class: stomp_moveit/MultiTrajectoryVisualization
         line_width: 0.02
         rgb: [255, 255, 0]
         marker_array_topic: stomp_trajectories
         marker_namespace: noisy
     update_filters:
+      - class: stomp_moveit/ConstrainedCartesianGoal
+        constrained_dofs: [1, 1, 1, 1, 1, 1]
+        cartesian_convergence: [0.005, 0.005, 0.005, 0.01, 0.01, 0.01]
+        joint_update_rates: [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+        max_ik_iterations: 100
       - class: stomp_moveit/UpdateLogger
         package: stomp_moveit
         directory: log
@@ -114,13 +124,18 @@ stomp/manipulator_tool:
     noisy_filters:
       - class: stomp_moveit/JointLimits
         lock_start: True
-        lock_goal: True
+        lock_goal: False
       - class: stomp_moveit/MultiTrajectoryVisualization
         line_width: 0.04
         rgb: [255, 255, 0]
         marker_array_topic: stomp_trajectories
         marker_namespace: noisy
     update_filters:
+      - class: stomp_moveit/ConstrainedCartesianGoal
+        constrained_dofs: [1, 1, 1, 1, 1, 1]
+        cartesian_convergence: [0.005, 0.005, 0.005, 0.01, 0.01, 0.01]
+        joint_update_rates: [0.01 , 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+        max_ik_iterations: 100
       - class: stomp_moveit/PolynomialSmoother
         poly_order: 5
       - class: stomp_moveit/TrajectoryVisualization


### PR DESCRIPTION
This PR makes some important changes:
- Replaced custom ik code with trac_ik due to better robustness and success rate.
- Updated the Stomp planner and plugins to use new track_ik functionality
- Tool constraints are no longer set in the Stomp yaml file, they are set in the motion plan request instead. The planer then determines the constraints from the request and evaluate that the goal has been met given the specified cartesian tolerances and tool pose.

I haven't added a formal unit test, however I have tested the planning under various scenarios (joint goal, fully constrained tool and under constrained) with nodes that aren't part of this repo.  I can make those into formal unit test if requested although that may take a bit more time. 