### PR TITLE
Fix partial derivative coefficients for jerk and expose smoothing derivative order

### DIFF
--- a/stomp_core/examples/simple_optimization_task.h
+++ b/stomp_core/examples/simple_optimization_task.h
@@ -53,7 +53,10 @@ public:
 
     // generate smoothing matrix
     int num_timesteps = parameters_bias.cols();
-    stomp_core::generateSmoothingMatrix(num_timesteps,1.0,smoothing_M_);
+    stomp_core::generateSmoothingMatrix(num_timesteps,
+                                        stomp_core::DerivativeOrders::STOMP_ACCELERATION,
+                                        1.0,
+                                        smoothing_M_);
     srand(time(0));
 
   }

--- a/stomp_core/examples/stomp_example.cpp
+++ b/stomp_core/examples/stomp_example.cpp
@@ -59,6 +59,7 @@ stomp_core::StompConfiguration create3DOFConfiguration()
   c.num_iterations_after_valid = 0;
   c.num_rollouts = 20;
   c.max_rollouts = 20;
+  c.smoothing_derivative_order = DerivativeOrders::STOMP_ACCELERATION;
   //! [Create Config]
 
   return c;

--- a/stomp_core/src/stomp.cpp
+++ b/stomp_core/src/stomp.cpp
@@ -366,8 +366,10 @@ bool Stomp::resetVariables()
   // generate finite difference matrix
   start_index_padded_ = FINITE_DIFF_RULE_LENGTH-1;
   num_timesteps_padded_ = config_.num_timesteps + 2*(FINITE_DIFF_RULE_LENGTH-1);
-  generateFiniteDifferenceMatrix(num_timesteps_padded_,DerivativeOrders::STOMP_ACCELERATION,
-                                 config_.delta_t,finite_diff_matrix_A_padded_);
+  generateFiniteDifferenceMatrix(num_timesteps_padded_,
+                                 static_cast<DerivativeOrders::DerivativeOrder>(config_.smoothing_derivative_order),
+                                 config_.delta_t,
+                                 finite_diff_matrix_A_padded_);
 
   /* control cost matrix (R = A_transpose * A):
    * Note: Original code multiplies the A product by the time interval.  However this is not

--- a/stomp_core/src/utils.cpp
+++ b/stomp_core/src/utils.cpp
@@ -61,7 +61,7 @@ void generateFiniteDifferenceMatrix(int num_time_steps,
   }
 }
 
-void generateSmoothingMatrix(int num_timesteps,double dt, Eigen::MatrixXd& projection_matrix_M)
+void generateSmoothingMatrix(int num_timesteps, DerivativeOrders::DerivativeOrder order, double dt, Eigen::MatrixXd& projection_matrix_M)
 {
   using namespace Eigen;
 
@@ -69,8 +69,7 @@ void generateSmoothingMatrix(int num_timesteps,double dt, Eigen::MatrixXd& proje
   int start_index_padded = FINITE_DIFF_RULE_LENGTH-1;
   int num_timesteps_padded = num_timesteps + 2*(FINITE_DIFF_RULE_LENGTH-1);
   MatrixXd finite_diff_matrix_A_padded;
-  generateFiniteDifferenceMatrix(num_timesteps_padded,DerivativeOrders::STOMP_ACCELERATION,
-                                 dt,finite_diff_matrix_A_padded);
+  generateFiniteDifferenceMatrix(num_timesteps_padded, order, dt, finite_diff_matrix_A_padded);
 
 
   /* computing control cost matrix (R = A_transpose * A):

--- a/stomp_core/test/stomp_3dof.cpp
+++ b/stomp_core/test/stomp_3dof.cpp
@@ -62,7 +62,7 @@ public:
 
     // generate smoothing matrix
     int num_timesteps = parameters_bias.cols();
-    generateSmoothingMatrix(num_timesteps,1.0,smoothing_M_);
+    generateSmoothingMatrix(num_timesteps, DerivativeOrders::STOMP_ACCELERATION, 1.0, smoothing_M_);
     srand(1);
 
   }

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -59,6 +59,7 @@ bool parseConfig(XmlRpc::XmlRpcValue config,const moveit::core::JointModelGroup*
   stomp_config.max_rollouts = 100;
   stomp_config.num_rollouts = 10;
   stomp_config.exponentiated_cost_sensitivity = 10.0;
+  stomp_config.smoothing_derivative_order = stomp_core::DerivativeOrders::STOMP_JERK;
 
   // Load optional config parameters if they exist
   if (config.hasMember("control_cost_weight"))
@@ -87,6 +88,9 @@ bool parseConfig(XmlRpc::XmlRpcValue config,const moveit::core::JointModelGroup*
 
   if (config.hasMember("exponentiated_cost_sensitivity"))
     stomp_config.exponentiated_cost_sensitivity = static_cast<int>(config["exponentiated_cost_sensitivity"]);
+
+  if (config.hasMember("smoothing_derivative_order"))
+    stomp_config.smoothing_derivative_order = static_cast<int>(config["smoothing_derivative_order"]);
 
   // getting number of joints
   stomp_config.num_dimensions = group->getActiveJointModels().size();

--- a/stomp_moveit/src/update_filters/control_cost_projection.cpp
+++ b/stomp_moveit/src/update_filters/control_cost_projection.cpp
@@ -80,7 +80,10 @@ bool ControlCostProjection::setMotionPlanRequest(const planning_scene::PlanningS
 {
 
   num_timesteps_ = config.num_timesteps;
-  stomp_core::generateSmoothingMatrix(num_timesteps_,DEFAULT_TIME_STEP,projection_matrix_M_);
+  stomp_core::generateSmoothingMatrix(num_timesteps_,
+                                      static_cast<stomp_core::DerivativeOrders::DerivativeOrder>(config.smoothing_derivative_order),
+                                      DEFAULT_TIME_STEP,
+                                      projection_matrix_M_);
 
   // zeroing out first and last rows
   projection_matrix_M_.topRows(1) = Eigen::VectorXd::Zero(num_timesteps_).transpose();


### PR DESCRIPTION
If smoothing derivative is set to Jerk it performs just as well as the polynomial smoother. Also thought it could be useful to be able to change this from the yaml file so I exposed it to the user.