### PR TITLE
Fix eigen warnings

### DIFF
--- a/constrained_ik/CMakeLists.txt
+++ b/constrained_ik/CMakeLists.txt
@@ -64,10 +64,10 @@ generate_dynamic_reconfigure_options(
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
- INCLUDE_DIRS include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS}
+ INCLUDE_DIRS include ${catkin_INCLUDE_DIRS}
  LIBRARIES constrained_ik constrained_ik_constraints moveit_clik_planner_plugin constrained_ik_plugin
  CATKIN_DEPENDS roscpp urdf eigen_conversions tf_conversions urdf moveit_ros_planning moveit_core dynamic_reconfigure kdl_parser cmake_modules industrial_collision_detection
- DEPENDS boost eigen orocos_kdl
+ DEPENDS Boost EIGEN3 orocos_kdl
 )
 
 ###########
@@ -144,7 +144,7 @@ install(
     ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-install(TARGETS constrained_ik_plugin moveit_clik_planner_plugin 
+install(TARGETS constrained_ik_plugin moveit_clik_planner_plugin
 ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -215,5 +215,3 @@ target_link_libraries(avoid_joint_vel_limits_example ${EXAMPLE_LIBS})
 
 add_executable(goal_tool_position_example examples/goal_tool_position_example.cpp examples/example_utils.h)
 target_link_libraries(goal_tool_position_example ${EXAMPLE_LIBS})
-
-

--- a/industrial_collision_detection/CMakeLists.txt
+++ b/industrial_collision_detection/CMakeLists.txt
@@ -3,16 +3,8 @@ project(industrial_collision_detection)
 
 add_definitions("-std=c++11")
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  cmake_modules
-  pluginlib
-  moveit_core
-  pcl_ros
-)
-
+find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
-find_package(Eigen REQUIRED)
 find_package(console_bridge REQUIRED)
 
 find_package(PkgConfig REQUIRED)
@@ -20,7 +12,13 @@ pkg_check_modules(LIBFCL REQUIRED fcl)
 find_library(LIBFCL_LIBRARIES_FULL ${LIBFCL_LIBRARIES} ${LIBFCL_LIBRARY_DIRS})
 set(LIBFCL_LIBRARIES "${LIBFCL_LIBRARIES_FULL}")
 
-
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  cmake_modules
+  pluginlib
+  moveit_core
+  pcl_ros
+)
 
 ###################################
 ## catkin specific configuration ##
@@ -32,27 +30,32 @@ set(LIBFCL_LIBRARIES "${LIBFCL_LIBRARIES_FULL}")
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
  INCLUDE_DIRS include ${catkin_INCLUDE_DIRS}
- LIBRARIES 
+ LIBRARIES
    ${PROJECT_NAME}
  CATKIN_DEPENDS roscpp moveit_core cmake_modules pluginlib pcl_ros
- DEPENDS boost eigen fcl
+ DEPENDS Boost EIGEN3
 )
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
-include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${EIGEN_INCLUDE_DIRS})
+include_directories(include
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
+  ${LIBFCL_INCLUDE_DIRS}
+)
 
 add_library(${PROJECT_NAME}
   src/collision_detection/collision_common.cpp
   src/collision_detection/collision_robot_industrial.cpp
   src/collision_detection/collision_world_industrial.cpp
 )
-target_link_libraries(${PROJECT_NAME} 
-  ${catkin_LIBRARIES} 
-  ${console_bridge_LIBRARIES} 
-  ${urdfdom_LIBRARIES} 
-  ${urdfdom_headers_LIBRARIES} 
-  ${LIBFCL_LIBRARIES} 
+target_link_libraries(${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+  ${console_bridge_LIBRARIES}
+  ${urdfdom_LIBRARIES}
+  ${urdfdom_headers_LIBRARIES}
+  ${LIBFCL_LIBRARIES}
   ${Boost_LIBRARIES})
 
 add_library(${PROJECT_NAME}_plugin

--- a/stomp_core/CMakeLists.txt
+++ b/stomp_core/CMakeLists.txt
@@ -1,14 +1,14 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(stomp_core)
 
+add_definitions("-std=c++11")
+
+find_package(Eigen3 REQUIRED)
+
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   cmake_modules
 )
-
-find_package(Eigen REQUIRED)
-
-add_definitions("-std=c++11")
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -17,10 +17,10 @@ add_definitions("-std=c++11")
 ## catkin specific configuration ##
 ###################################
 catkin_package(
-  INCLUDE_DIRS include ${EIGEN_INCLUDE_DIRS}
+  INCLUDE_DIRS include
   LIBRARIES stomp_core
   CATKIN_DEPENDS roscpp cmake_modules
-  DEPENDS Eigen
+  DEPENDS EIGEN3
 )
 
 ###########
@@ -30,7 +30,7 @@ include_directories(
   include
   examples
   ${catkin_INCLUDE_DIRS}
-  ${EIGEN_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library

--- a/stomp_moveit/CMakeLists.txt
+++ b/stomp_moveit/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(stomp_moveit)
+
+add_definitions("-std=c++11")
+
+find_package(Eigen3 REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
+
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   moveit_core
@@ -8,11 +14,6 @@ find_package(catkin REQUIRED COMPONENTS
   cmake_modules
   pluginlib
 )
-find_package(Eigen REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system)
-
-add_definitions("-std=c++11")
-
 
 ###################################
 ## catkin specific configuration ##
@@ -21,7 +22,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS moveit_ros_planning moveit_core stomp_core cmake_modules pluginlib roscpp
-  DEPENDS Eigen
+  DEPENDS EIGEN3
 )
 
 ###########
@@ -30,7 +31,8 @@ catkin_package(
 
 ## Specify additional locations of header files
 include_directories(include
-    ${catkin_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library
@@ -58,7 +60,7 @@ target_link_libraries(${PROJECT_NAME}_cost_functions ${catkin_LIBRARIES})
 
 # filter plugin(s)
 add_library(${PROJECT_NAME}_noisy_filters
-  src/noisy_filters/joint_limits.cpp  
+  src/noisy_filters/joint_limits.cpp
   src/noisy_filters/multi_trajectory_visualization.cpp
 )
 
@@ -89,7 +91,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 )
 
 ## Mark executables and/or libraries for installation
-install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_planner_manager ${PROJECT_NAME}_cost_functions 
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_planner_manager ${PROJECT_NAME}_cost_functions
   ${PROJECT_NAME}_noisy_filters ${PROJECT_NAME}_update_filters ${PROJECT_NAME}_noise_generators
 ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -110,4 +112,3 @@ install(
 #############
 ## Testing ##
 #############
-

--- a/stomp_plugins/CMakeLists.txt
+++ b/stomp_plugins/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   pluginlib
 )
 
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
 
 add_definitions("-std=c++11")
@@ -28,7 +28,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS moveit_ros_planning moveit_core stomp_core stomp_moveit cmake_modules pluginlib roscpp
-  DEPENDS Eigen
+  DEPENDS EIGEN3
 )
 
 ###########
@@ -37,7 +37,8 @@ catkin_package(
 
 ## Specify additional locations of header files
 include_directories(include
-    ${catkin_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
 )
 
 # cost function plugin(s)
@@ -80,4 +81,3 @@ install(FILES cost_function_plugins.xml noise_generator_plugins.xml update_filte
 #############
 ## Testing ##
 #############
-


### PR DESCRIPTION
Fixes all FCL, Boost, and Eigen warnings including:

```
Warnings   << stomp_core:cmake /home/dave/ros/current/ws_moveit/logs/stomp_core/build.cmake.000.log
CMake Warning at /opt/ros/kinetic/share/cmake_modules/cmake/Modules/FindEigen.cmake:62 (message):
  The FindEigen.cmake Module in the cmake_modules package is deprecated.

  Please use the FindEigen3.cmake Module provided with Eigen.  Change
  instances of find_package(Eigen) to find_package(Eigen3).  Check the
  FindEigen3.cmake Module for the resulting CMake variable names.
```