### PR TITLE
Removed polynomial smoothing applied when seeding trajectories to STOMP

### DIFF
--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -430,11 +430,6 @@ bool StompPlanner::getSeedParameters(Eigen::MatrixXd& parameters) const
     return false;
   }
 
-  if(!applyPolynomialSmoothing(robot_model_,group_,parameters,5,1e-5))
-  {
-    return false;
-  }
-
   return true;
 }
 


### PR DESCRIPTION
See #57 

Removed the polynomial smoothing filter that was being applied to the initial trajectory when seeding to STOMP. In some use-cases, this would cause previously valid trajectories to become invalidated.