### PR TITLE
Fix STOMP crash when planning fails

### DIFF
--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -160,9 +160,10 @@ bool StompPlanner::solve(planning_interface::MotionPlanResponse &res)
   ros::WallTime start_time = ros::WallTime::now();
   planning_interface::MotionPlanDetailedResponse detailed_res;
   bool success = solve(detailed_res);
-
-  // construct the compact response from the detailed one
-  res.trajectory_ = detailed_res.trajectory_.back();
+  if(success)
+  {
+    res.trajectory_ = detailed_res.trajectory_.back();
+  }
   ros::WallDuration wd = ros::WallTime::now() - start_time;
   res.planning_time_ = ros::Duration(wd.sec, wd.nsec).toSec();
   res.error_code_ = detailed_res.error_code_;


### PR DESCRIPTION
On the rare occasions when planning fails and STOMP is accessed through the `StompPlanner::solve(planning_interface::MotionPlanResponse &res)` function the system crashes when trying to copy planned trajectory over.

I think that the assumption of `success == true` therefore `detailed_res.trajectory_ is not empty` stands and should stand so it is safe to only check for `success`.

Sorry for not submitting a supporting test along with it.

`std::vector::back()`: "Calling this function on an empty container causes undefined behavior."
Source: http://www.cplusplus.com/reference/vector/vector/back/