### PR TITLE
Add support for Cartesian seed

### DIFF
--- a/stomp_core/include/stomp_core/stomp.h
+++ b/stomp_core/include/stomp_core/stomp.h
@@ -93,6 +93,8 @@ public:
    */
   bool clear();
 
+  unsigned int getNumIterations(){return current_iteration_;}
+
 
 protected:
 

--- a/stomp_core/src/stomp.cpp
+++ b/stomp_core/src/stomp.cpp
@@ -777,10 +777,9 @@ bool Stomp::computeOptimizedCost()
 
   // state costs
   if(task_->computeCosts(parameters_optimized_,
-                         0,config_.num_timesteps,current_iteration_,parameters_state_costs_,parameters_valid_))
+                         0,config_.num_timesteps,current_iteration_,
+                         parameters_state_costs_,parameters_valid_))
   {
-
-
     parameters_total_cost_ += parameters_state_costs_.sum();
   }
   else

--- a/stomp_moveit/CMakeLists.txt
+++ b/stomp_moveit/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   stomp_core
   cmake_modules
   pluginlib
+  trac_ik_lib
 )
 
 ###################################

--- a/stomp_moveit/include/stomp_moveit/rosconsolecolours.h
+++ b/stomp_moveit/include/stomp_moveit/rosconsolecolours.h
@@ -5,7 +5,7 @@
 #include <deque>
 #include <ros/console.h>
 #include <iostream>
-
+#include <Eigen/Eigen>
 
 #define ROS_RED_STREAM(SSS) ROS_INFO_STREAM("\033[31;1m" << SSS << "\033[0m\n")
 #define ROS_GREEN_STREAM(SSS) ROS_INFO_STREAM("\033[32;1m" << SSS << "\033[0m\n")
@@ -31,6 +31,13 @@ std::ostream& operator<< (std::ostream& stream, const std::deque<T>& list)
     stream << elem << ", ";
   stream.seekp(-2, std::ios_base::end); // remove last ", "
   return stream;
+}
+
+std::string shape(const Eigen::MatrixXd& mat)
+{
+  std::stringstream ss;
+  ss << "(" << mat.rows() << "," << mat.cols() << ")";
+  return ss.str();
 }
 
 /* free test code here

--- a/stomp_moveit/include/stomp_moveit/rosconsolecolours.h
+++ b/stomp_moveit/include/stomp_moveit/rosconsolecolours.h
@@ -1,0 +1,46 @@
+#ifndef ROSCONSOLECOLOURS_H
+#define ROSCONSOLECOLOURS_H
+
+#include <vector>
+#include <deque>
+#include <ros/console.h>
+#include <iostream>
+
+
+#define ROS_RED_STREAM(SSS) ROS_INFO_STREAM("\033[31;1m" << SSS << "\033[0m\n")
+#define ROS_GREEN_STREAM(SSS) ROS_INFO_STREAM("\033[32;1m" << SSS << "\033[0m\n")
+#define ROS_YELLOW_STREAM(SSS) ROS_INFO_STREAM("\033[33;1m" << SSS << "\033[0m\n")
+#define ROS_BLUE_STREAM(SSS) ROS_INFO_STREAM("\033[34;1m" << SSS << "\033[0m\n")
+#define ROS_MAGENTA_STREAM(SSS) ROS_INFO_STREAM("\033[35;1m" << SSS << "\033[0m\n")
+#define ROS_CYAN_STREAM(SSS) ROS_INFO_STREAM("\033[36;1m" << SSS << "\033[0m\n")
+#define ROS_WHITE_STREAM(SSS) ROS_INFO_STREAM("\033[30;47m" << SSS << "\033[0m\n")
+
+template <typename T>
+std::ostream& operator<< (std::ostream& stream, const std::vector<T>& list)
+{
+  for(const T& elem : list)
+    stream << elem << ", ";
+  stream.seekp(-2, std::ios_base::end); // remove last ", "
+  return stream;
+}
+
+template <typename T>
+std::ostream& operator<< (std::ostream& stream, const std::deque<T>& list)
+{
+  for(const T& elem : list)
+    stream << elem << ", ";
+  stream.seekp(-2, std::ios_base::end); // remove last ", "
+  return stream;
+}
+
+/* free test code here
+ROS_RED_STREAM("bold red text");
+ROS_YELLOW_STREAM("yellow stuff");
+ROS_GREEN_STREAM("Green stuff");
+ROS_BLUE_STREAM("blue");
+ROS_CYAN_STREAM("cyan is different fromb blue");
+ROS_MAGENTA_STREAM("magenta is not pink or is it?");
+ROS_WHITE_STREAM("white bricks");
+*/
+
+#endif

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -160,9 +160,9 @@ protected:
   *  each entry in the array is considered to be joint values for that time step.
   */
   bool ikFromCartesianConstraints(const moveit_msgs::PositionConstraint& pos_constraint,
-                                         const moveit_msgs::OrientationConstraint& orient_constraint,
-                                         Eigen::VectorXd& start, Eigen::VectorXd& goal,
-                                         const moveit::core::JointModelGroup* joint_group, moveit::core::RobotStatePtr state) const;
+                                  const moveit_msgs::OrientationConstraint& orient_constraint,
+                                  const moveit::core::JointModelGroup* joint_group,
+                                  Eigen::VectorXd& result) const;
 
   bool isCartesianSeed() const;
 

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -155,6 +155,15 @@ protected:
    */
   bool extractSeedTrajectory(const moveit_msgs::MotionPlanRequest& req, trajectory_msgs::JointTrajectory& seed) const;
 
+ /**
+  * @brief Populates a seed joint trajectory from the 'trajectory_constraints' moveit_msgs::Constraints[] array.
+  *  each entry in the array is considered to be joint values for that time step.
+  */
+  bool ikFromCartesianConstraints(const moveit_msgs::PositionConstraint& pos_constraint,
+                                         const moveit_msgs::OrientationConstraint& orient_constraint,
+                                         Eigen::VectorXd& start, Eigen::VectorXd& goal,
+                                         const moveit::core::JointModelGroup* joint_group, moveit::core::RobotStatePtr state) const;
+
 protected:
 
   // stomp optimization

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -155,6 +155,10 @@ protected:
    */
   bool extractSeedTrajectory(const moveit_msgs::MotionPlanRequest& req, trajectory_msgs::JointTrajectory& seed) const;
 
+  bool extractSeedJointTrajectory(const moveit_msgs::MotionPlanRequest& req, trajectory_msgs::JointTrajectory& seed) const;
+
+  bool extractSeedCartesianTrajectory(const moveit_msgs::MotionPlanRequest& req, trajectory_msgs::JointTrajectory& seed) const;
+
  /**
   * @brief Populates a seed joint trajectory from the 'trajectory_constraints' moveit_msgs::Constraints[] array.
   *  each entry in the array is considered to be joint values for that time step.

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -164,6 +164,8 @@ protected:
                                          Eigen::VectorXd& start, Eigen::VectorXd& goal,
                                          const moveit::core::JointModelGroup* joint_group, moveit::core::RobotStatePtr state) const;
 
+  bool isCartesianSeed() const;
+
 protected:
 
   // stomp optimization

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -171,9 +171,9 @@ protected:
 
   bool isCartesianSeed() const;
 
-  moveit_msgs::RobotState robotStateFromEigen(const Eigen::VectorXd& state, const std::vector<std::string> &state_joint_names, const std::vector<std::string> &all_joint_names) const;
+  moveit_msgs::RobotState robotStateFromEigen(const Eigen::MatrixXd& state, const std::vector<std::string> &state_joint_names, const std::vector<std::string> &all_joint_names) const;
 
-  moveit_msgs::Constraints jointConstraintsFromEigen(const Eigen::VectorXd& state, const std::vector<std::string>& state_joint_names) const;
+  moveit_msgs::Constraints jointConstraintsFromEigen(const Eigen::MatrixXd& state, const std::vector<std::string>& state_joint_names) const;
 
 protected:
 

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -160,26 +160,7 @@ protected:
 
   bool extractSeedCartesianTrajectory(const moveit_msgs::MotionPlanRequest& req, trajectory_msgs::JointTrajectory& seed) const;
 
- /**
-  * @brief Populates a seed joint trajectory from the 'trajectory_constraints' moveit_msgs::Constraints[] array.
-  *  each entry in the array is considered to be joint values for that time step.
-  */
-  bool ikFromCartesianConstraints(const moveit_msgs::PositionConstraint& pos_constraint,
-                                  const moveit_msgs::OrientationConstraint& orient_constraint,
-                                  const moveit::core::JointModelGroup* joint_group,
-                                  Eigen::VectorXd& result,
-                                  TRAC_IK::TRAC_IK& tracik_solver,
-                                  const Eigen::VectorXd &hint = Eigen::VectorXd()) const;
-
   bool isCartesianSeed() const;
-
-  moveit_msgs::RobotState robotStateFromEigen(const Eigen::MatrixXd& state, const std::vector<std::string> &state_joint_names, const std::vector<std::string> &all_joint_names) const;
-
-  moveit_msgs::Constraints jointConstraintsFromEigen(const Eigen::MatrixXd& state, const std::vector<std::string>& state_joint_names) const;
-
-  bool robotStateToEigen(const sensor_msgs::JointState& state, Eigen::VectorXd& target) const;
-
-  KDL::Frame positionConstraintsToKDLFrame(const moveit_msgs::PositionConstraint& pos_constraint) const;
 
 protected:
 

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -31,6 +31,7 @@
 #include <stomp_moveit/stomp_optimization_task.h>
 #include <boost/thread.hpp>
 #include <ros/ros.h>
+#include <trac_ik/trac_ik.hpp>
 
 namespace stomp_moveit
 {
@@ -167,6 +168,7 @@ protected:
                                   const moveit_msgs::OrientationConstraint& orient_constraint,
                                   const moveit::core::JointModelGroup* joint_group,
                                   Eigen::VectorXd& result,
+                                  TRAC_IK::TRAC_IK& tracik_solver,
                                   const Eigen::VectorXd &hint = Eigen::VectorXd()) const;
 
   bool isCartesianSeed() const;

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -171,9 +171,9 @@ protected:
 
   bool isCartesianSeed() const;
 
-  moveit_msgs::RobotState robotStateFromEigen(const Eigen::VectorXd& state, const moveit::core::JointModelGroup* joint_group) const;
+  moveit_msgs::RobotState robotStateFromEigen(const Eigen::VectorXd& state, const std::vector<std::string> &state_joint_names, const std::vector<std::string> &all_joint_names) const;
 
-  moveit_msgs::Constraints jointConstraintsFromEigen(const Eigen::VectorXd& state, const moveit::core::JointModelGroup* joint_group) const;
+  moveit_msgs::Constraints jointConstraintsFromEigen(const Eigen::VectorXd& state, const std::vector<std::string>& state_joint_names) const;
 
 protected:
 

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -188,6 +188,9 @@ protected:
 
   // ros tasks
   ros::NodeHandlePtr ph_;
+
+  bool publish_seed_trajectory_;
+  ros::Publisher seed_trajectory_publisher_;
 };
 
 

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -177,6 +177,8 @@ protected:
 
   moveit_msgs::Constraints jointConstraintsFromEigen(const Eigen::MatrixXd& state, const std::vector<std::string>& state_joint_names) const;
 
+  bool robotStateToEigen(const sensor_msgs::JointState& state, Eigen::VectorXd& target) const;
+
 protected:
 
   // stomp optimization

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -179,6 +179,8 @@ protected:
 
   bool robotStateToEigen(const sensor_msgs::JointState& state, Eigen::VectorXd& target) const;
 
+  KDL::Frame positionConstraintsToKDLFrame(const moveit_msgs::PositionConstraint& pos_constraint) const;
+
 protected:
 
   // stomp optimization

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -162,7 +162,8 @@ protected:
   bool ikFromCartesianConstraints(const moveit_msgs::PositionConstraint& pos_constraint,
                                   const moveit_msgs::OrientationConstraint& orient_constraint,
                                   const moveit::core::JointModelGroup* joint_group,
-                                  Eigen::VectorXd& result) const;
+                                  Eigen::VectorXd& result,
+                                  const Eigen::VectorXd &hint = Eigen::VectorXd()) const;
 
   bool isCartesianSeed() const;
 

--- a/stomp_moveit/include/stomp_moveit/stomp_planner.h
+++ b/stomp_moveit/include/stomp_moveit/stomp_planner.h
@@ -171,6 +171,10 @@ protected:
 
   bool isCartesianSeed() const;
 
+  moveit_msgs::RobotState robotStateFromEigen(const Eigen::VectorXd& state, const moveit::core::JointModelGroup* joint_group) const;
+
+  moveit_msgs::Constraints jointConstraintsFromEigen(const Eigen::VectorXd& state, const moveit::core::JointModelGroup* joint_group) const;
+
 protected:
 
   // stomp optimization

--- a/stomp_moveit/include/stomp_moveit/utils/kinematics.h
+++ b/stomp_moveit/include/stomp_moveit/utils/kinematics.h
@@ -343,6 +343,7 @@ namespace kinematics
     {
       if(joint_names.size() != joint_vals.size())
       {
+        ROS_ERROR("STOMP::solveIK: Mismatching number of joints");
         return false;
       }
 

--- a/stomp_moveit/include/stomp_moveit/utils/kinematics.h
+++ b/stomp_moveit/include/stomp_moveit/utils/kinematics.h
@@ -33,19 +33,17 @@
 #include <moveit/robot_state/conversions.h>
 #include <pluginlib/class_list_macros.h>
 #include <XmlRpcException.h>
-#include <moveit_msgs/PositionConstraint.h>
-#include <moveit_msgs/OrientationConstraint.h>
+#include <moveit_msgs/Constraints.h>
+#include <stomp_moveit/rosconsolecolours.h>
+#include <trac_ik/trac_ik.hpp>
 
 
 namespace stomp_moveit
 {
+
 namespace utils
 {
 
-/**
- * @namespace stomp_moveit::utils::kinematics
- * @brief Utility functions related to finding Inverse Kinematics solutions
- */
 namespace kinematics
 {
 
@@ -584,6 +582,225 @@ namespace kinematics
             ArrayXd::Zero(joint_update_rates.size()),VectorXd::Zero(joint_update_rates.size()),max_iterations,
             tool_goal_pose,init_joint_pose,joint_pose);
   }
+
+
+  KDL::Frame positionConstraintsToKDLFrame(const moveit_msgs::PositionConstraint& c)
+  {
+    KDL::Frame result;
+    // some interfaces define position constraints as "target_point_offset" while others use "constraint_region"
+    if(not c.constraint_region.primitive_poses.empty())
+    {
+      result.p[0] = c.constraint_region.primitive_poses.front().position.x;
+      result.p[1] = c.constraint_region.primitive_poses.front().position.y;
+      result.p[2] = c.constraint_region.primitive_poses.front().position.z;
+    }
+    else
+    {
+      result.p[0] = c.target_point_offset.x;
+      result.p[1] = c.target_point_offset.y;
+      result.p[2] = c.target_point_offset.z;
+    }
+    return result;
+  }
+
+  moveit_msgs::Constraints jointConstraintsFromEigen(const Eigen::MatrixXd& state, 
+                                                     const std::vector<std::string>& state_joint_names)
+  {
+    //ROS_GREEN_STREAM("Shape is " << shape(state));
+    assert(state.size() == state_joint_names.size());
+
+    moveit_msgs::Constraints result;
+
+    ROS_CYAN_STREAM(state_joint_names);
+    ROS_CYAN_STREAM(state);
+
+    for(int i=0; i<state_joint_names.size(); ++i)
+    {
+      moveit_msgs::JointConstraint joint_constraint;
+      joint_constraint.joint_name = state_joint_names[i];
+      joint_constraint.position = state(i,0);
+      result.joint_constraints.push_back(joint_constraint);
+    }
+
+    return result;
+  }
+
+  moveit_msgs::RobotState robotStateFromEigen(const Eigen::MatrixXd& state,
+                                              const std::vector<std::string>& state_joint_names,
+                                              const std::vector<std::string>& all_joint_names)
+  {
+    //ROS_GREEN_STREAM("Shape is " << shape(state));
+
+    //assert(state.size() == state_joint_names.size());
+
+    moveit_msgs::RobotState result;
+
+    result.is_diff = false;
+    result.joint_state.name = all_joint_names;
+    result.joint_state.position.resize(all_joint_names.size(), 0.0);
+
+    for(int i=0; i<all_joint_names.size(); ++i)
+    {
+      for(int j=0; j<state_joint_names.size(); ++j)
+      {
+        if(all_joint_names[i] == state_joint_names[j])
+          result.joint_state.position[i] = state(j,0);
+      }
+    }
+
+    return result;
+  }
+
+  bool robotStateToEigen(const sensor_msgs::JointState& state,
+                         const moveit::core::RobotState& robot_model,
+                         const std::string& group_name,
+                         Eigen::VectorXd& target)
+  {
+    if(state.name.empty() || state.position.empty())
+    {
+      ROS_ERROR("JointState message lacks names or positions");
+      return false;
+    }
+
+    moveit::core::RobotStatePtr tmp_state(new moveit::core::RobotState(robot_model));
+    tmp_state->setVariableValues(state);  
+
+    if(!tmp_state->satisfiesBounds())
+    {
+      ROS_ERROR("Joint state is out of bounds");
+      return false;
+    }
+
+    // copying start joint values
+    const auto joint_names = tmp_state->getJointModelGroup(group_name)->getActiveJointModelNames();
+    target.resize(joint_names.size());
+
+    for(auto j = 0; j < joint_names.size(); j++)
+    {
+      target(j) = tmp_state->getVariablePosition(joint_names[j]);
+    }
+
+    return true;
+  }
+
+
+  Eigen::VectorXd filter(const moveit::core::JointModelGroup* jmg, const Eigen::VectorXd& vec)
+  {
+    Eigen::VectorXd filtered(jmg->getActiveJointModelNames().size());
+
+    ROS_CYAN_STREAM(jmg->getActiveJointModelNames());
+
+    const std::vector<unsigned int>& bij = jmg->getKinematicsSolverJointBijection();
+    //ROS_YELLOW_STREAM(bij);
+
+    for (std::size_t i = 0; i < bij.size(); ++i)
+      filtered[bij[i]] = vec[i];
+
+    return filtered;
+  }
+
+  std::map<std::string, double> 
+  getFixedJointsMap(const std::string& urdf_param, const std::string& base_frame, 
+                    const std::string& end_eff_frame, const moveit::core::JointModelGroup* jmg, 
+                    const sensor_msgs::JointState& start_state)
+  {
+    std::map<std::string, double> fixed_joints;
+
+    //  not going to use this solver, only need it to parse the urdf and gives us the chain
+    TRAC_IK::TRAC_IK solver(base_frame, end_eff_frame, urdf_param);
+    KDL::Chain chain;
+    if(not solver.getKDLChain(chain))
+    {
+      ROS_FATAL("Solver failed to set up, this shouldn't happen!");
+    }
+
+    const auto& activeJMGJoints = jmg->getActiveJointModelNames();
+
+    for(const KDL::Segment& s : chain.segments)
+    {
+      const KDL::Joint& joint = s.getJoint();
+      if(joint.getType() != KDL::Joint::None)
+      {
+        auto result = std::find(std::begin(activeJMGJoints), std::end(activeJMGJoints), joint.getName());
+        if(result != std::end(activeJMGJoints))
+        {
+          ROS_GREEN_STREAM(joint.getName());
+        }
+        else
+        {
+          ROS_RED_STREAM(joint.getName());
+          size_t idx = std::distance(start_state.name.begin(), find(start_state.name.begin(), start_state.name.end(), joint.getName()));
+          fixed_joints[joint.getName()] = start_state.position[idx];
+          //result.insert( std::pair<std::string, double>(joint.getName(), start_state.position[idx]));
+        }
+      }
+      else
+      {
+        ROS_YELLOW_STREAM(joint.getName());
+      }
+    }
+
+    ROS_WHITE_STREAM("Fixed joints:");
+    for(const auto& p : fixed_joints)
+      ROS_WHITE_STREAM("(" << p.first << ", " << p.second << ")");
+
+    return fixed_joints;
+  }
+
+  /**
+   * @brief Populates a seed joint trajectory from the 'trajectory_constraints' moveit_msgs::Constraints[] array.
+   *  each entry in the array is considered to be joint values for that time step.
+   */
+  bool ikFromCartesianConstraints(const moveit_msgs::PositionConstraint& pos_constraint,
+                                  const moveit_msgs::OrientationConstraint& orient_constraint,
+                                  const moveit::core::JointModelGroup* joint_group,
+                                  Eigen::VectorXd& result,
+                                  TRAC_IK::TRAC_IK& tracik_solver,
+                                  const Eigen::VectorXd& hint = Eigen::VectorXd())
+  {
+    ROS_ASSERT(joint_group->getJointRoots().size() == 1);
+
+    KDL::Chain chain;
+    if(not tracik_solver.getKDLChain(chain))
+      return false;
+
+    KDL::Frame end_effector_pose = positionConstraintsToKDLFrame(pos_constraint);
+
+    end_effector_pose.M = KDL::Rotation::Quaternion(orient_constraint.orientation.x, orient_constraint.orientation.y,
+                                                    orient_constraint.orientation.z, orient_constraint.orientation.w);
+
+    // Create Nominal chain configuration midway between all joint limits
+    KDL::JntArray ik_result;
+    KDL::JntArray nominal(chain.getNrOfJoints());
+
+    if(hint.size() > 0)
+    {
+      //ROS_ERROR_STREAM("Using " << hint << " as IK hint");
+      nominal.data = hint;
+    }
+
+    KDL::Twist tolerance;
+    tolerance.rot.x(0.1);tolerance.rot.y(0.1);tolerance.rot.z(0.1);
+    tolerance.vel.x(0.05);tolerance.vel.y(0.05);tolerance.vel.z(0.05);
+
+    int rc=tracik_solver.CartToJnt(nominal,end_effector_pose,ik_result, tolerance);
+
+    if(rc >= 0)
+    {
+      ROS_YELLOW_STREAM("IK done, shape is " << shape(result));
+      result = ik_result.data;
+      return true;
+    }
+    else
+    {
+      ROS_WHITE_STREAM("IK queried EEF pose: (" <<
+                       end_effector_pose.p[0] << ", " <<
+                       end_effector_pose.p[1] << ", " <<
+                       end_effector_pose.p[2] << ")");
+      return false;
+    }
+  }
+
 
 
 } // kinematics

--- a/stomp_moveit/package.xml
+++ b/stomp_moveit/package.xml
@@ -17,6 +17,7 @@
   <build_depend>stomp_core</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>trac_ik_lib</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
@@ -24,6 +25,7 @@
   <run_depend>stomp_core</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>cmake_modules</run_depend>
+  <run_depend>trac_ik_lib</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/stomp_moveit/src/cost_functions/collision_check.cpp
+++ b/stomp_moveit/src/cost_functions/collision_check.cpp
@@ -170,11 +170,11 @@ bool CollisionCheck::setMotionPlanRequest(const planning_scene::PlanningSceneCon
 
   // storing robot state
   robot_state_.reset(new RobotState(robot_model_ptr_));
-  if(!robotStateMsgToRobotState(req.start_state,*robot_state_,true))
-  {
-    ROS_ERROR("%s Failed to get current robot state from request",getName().c_str());
-    return false;
-  }
+//  if(!robotStateMsgToRobotState(req.start_state,*robot_state_,true))
+//  {
+//    ROS_ERROR("%s Failed to get current robot state from request",getName().c_str());
+//    return false;
+//  }
 
   // copying into intermediate robot states
   for(auto& rs : intermediate_coll_states_)

--- a/stomp_moveit/src/cost_functions/collision_check.cpp
+++ b/stomp_moveit/src/cost_functions/collision_check.cpp
@@ -367,7 +367,7 @@ bool CollisionCheck::configure(const XmlRpc::XmlRpcValue& config)
   {
     if(!config.hasMember(m))
     {
-      ROS_ERROR("%s failed to find one or more required parameters",getName().c_str());
+      ROS_ERROR_STREAM_NAMED(getName().c_str(), "failed to find required parameter:" << m);
       return false;
     }
   }

--- a/stomp_moveit/src/noisy_filters/joint_limits.cpp
+++ b/stomp_moveit/src/noisy_filters/joint_limits.cpp
@@ -113,6 +113,13 @@ bool JointLimits::setMotionPlanRequest(const planning_scene::PlanningSceneConstP
     ROS_WARN("%s Requested Start State is out of bounds",getName().c_str());
   }
 
+
+  if(req.goal_constraints.empty())
+  {
+      ROS_WARN_NAMED(getName().c_str(), "CANNOT LOCK GOAL: Goal State is not specified. Moving on as if lock_goal was false.");
+      lock_goal_ = false;
+  }
+
   // saving goal state
   if(lock_goal_)
   {

--- a/stomp_moveit/src/noisy_filters/joint_limits.cpp
+++ b/stomp_moveit/src/noisy_filters/joint_limits.cpp
@@ -108,7 +108,7 @@ bool JointLimits::setMotionPlanRequest(const planning_scene::PlanningSceneConstP
     return false;
   }
 
-  if(!start_state_->satisfiesBounds(robot_model_->getJointModelGroup(group_name_)))
+  if(!start_state_->satisfiesBounds(robot_model_->getJointModelGroup(group_name_), 0.01))
   {
     ROS_WARN("%s Requested Start State is out of bounds",getName().c_str());
   }
@@ -124,13 +124,14 @@ bool JointLimits::setMotionPlanRequest(const planning_scene::PlanningSceneConstP
         goal_state_->setVariablePosition(jc.joint_name,jc.position);
         goal_state_saved = true;
       }
-
-      if(!goal_state_->satisfiesBounds(robot_model_->getJointModelGroup(group_name_)))
+      if(not gc.joint_constraints.empty())
       {
-        ROS_WARN("%s Requested Goal State is out of bounds",getName().c_str());
+        if(!goal_state_->satisfiesBounds(robot_model_->getJointModelGroup(group_name_), 0.1))
+        {
+          ROS_WARN("%s Requested Goal State is out of bounds",getName().c_str());
+          break;
+        }
       }
-
-      break;
     }
 
     if(!goal_state_saved)

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -703,7 +703,7 @@ bool StompPlanner::ikFromCartesianConstraints(const moveit_msgs::PositionConstra
   }
 
   KDL::Twist tolerance;
-  tolerance.rot.x(0.01);tolerance.rot.y(0.01);tolerance.rot.z(0.01);
+  tolerance.rot.x(0.2);tolerance.rot.y(0.2);tolerance.rot.z(0.2);
   tolerance.vel.x(0.01);tolerance.vel.y(0.01);tolerance.vel.z(0.01);
 
   int rc=tracik_solver.CartToJnt(nominal,end_effector_pose,ik_result, tolerance);

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -592,6 +592,8 @@ bool StompPlanner::extractSeedCartesianTrajectory(const moveit_msgs::MotionPlanR
   TRAC_IK::TRAC_IK tracik_solver(base_frame, end_eff_frame, urdf_param, timeout, eps);
 
   Eigen::VectorXd joint_pos;
+  robotStateToEigen(req.start_state.joint_state, joint_pos);
+  
   for (size_t i = 0; i < constraints[0].position_constraints.size(); ++i)
   {
     trajectory_msgs::JointTrajectoryPoint joint_pt;

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -621,6 +621,7 @@ bool StompPlanner::extractSeedCartesianTrajectory(const moveit_msgs::MotionPlanR
   }
 
   ROS_WARN_STREAM("Seed trajectory converted with a total of " << fail_count << "/" << seed.points.size() << " IK FAILURES");
+  ROS_YELLOW_STREAM("IK solver is using " << base_frame << " for base frame and " << end_eff_frame << " for end effector frame");
 
   seed.joint_names = joint_group->getActiveJointModelNames();
   return true;
@@ -742,10 +743,15 @@ bool StompPlanner::ikFromCartesianConstraints(const moveit_msgs::PositionConstra
   }
   else
   {
-    ROS_WARN("Failed to get IK");
+    ROS_ERROR("Failed to get IK");
     ROS_WARN_STREAM(pos_constraint.constraint_region);
     ROS_WARN_STREAM(pos_constraint.target_point_offset);
     ROS_WARN_STREAM(orient_constraint.orientation);
+
+    ROS_WHITE_STREAM("IK queried EEF pose: (" <<
+                     end_effector_pose.p[0] << ", " <<
+                     end_effector_pose.p[1] << ", " <<
+                     end_effector_pose.p[2] << ")");
     return false;
   }
 }

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -307,7 +307,7 @@ bool StompPlanner::solve(planning_interface::MotionPlanDetailedResponse &res)
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
     return false;
   }
-
+  trajectory.header.seq=stomp_->getNumIterations(); //number of iterations
   // checking against planning scene
   if(planning_scene_ && !planning_scene_->isPathValid(*res.trajectory_.back(),group_,true))
   {

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -695,6 +695,24 @@ bool StompPlanner::isCartesianSeed() const
   }
 }
 
+moveit_msgs::RobotState StompPlanner::robotStateFromEigen(const Eigen::VectorXd& state, const JointModelGroup* joint_group) const
+{
+  moveit_msgs::RobotState result;
+
+  assert(false); // FINISH THIS
+
+  return result;
+}
+
+moveit_msgs::Constraints StompPlanner::jointConstraintsFromEigen(const Eigen::VectorXd& state, const JointModelGroup* joint_group) const
+{
+  moveit_msgs::Constraints result;
+
+  assert(false); // FINISH THIS
+
+  return result;
+}
+
 bool StompPlanner::getStartAndGoal(Eigen::VectorXd& start, Eigen::VectorXd& goal)
 {
   using namespace moveit::core;
@@ -730,9 +748,18 @@ bool StompPlanner::getStartAndGoal(Eigen::VectorXd& start, Eigen::VectorXd& goal
                                             joint_group, goal);
     ROS_ERROR_COND(!found_goal, "STOMP failed to get the goal positions");
 
-
     ROS_ERROR_STREAM("Start joint state " << std::endl << start);
     ROS_ERROR_STREAM("Goal joint state " << std::endl << goal);
+
+    //FIXME: stateful cheat, system design failure:
+    // now that IK was ran on the cartesian seed trajectory, we set the start_state and goal_constraints of the original request
+    // this helps not messing up all the cost functions that are wired for using lots of global state from these variables
+    if(found_goal and found_start)
+    {
+      request_.start_state = robotStateFromEigen(start, joint_group);
+      request_.goal_constraints.clear();
+      request_.goal_constraints.push_back(jointConstraintsFromEigen(goal, joint_group));
+    }
 
     return found_goal and found_start;
   }

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -734,8 +734,8 @@ bool StompPlanner::ikFromCartesianConstraints(const moveit_msgs::PositionConstra
   }
 
   KDL::Twist tolerance;
-  tolerance.rot.x(0.2);tolerance.rot.y(0.2);tolerance.rot.z(0.2);
-  tolerance.vel.x(0.01);tolerance.vel.y(0.01);tolerance.vel.z(0.01);
+  tolerance.rot.x(0.1);tolerance.rot.y(0.1);tolerance.rot.z(0.1);
+  tolerance.vel.x(0.05);tolerance.vel.y(0.05);tolerance.vel.z(0.05);
 
   int rc=tracik_solver.CartToJnt(nominal,end_effector_pose,ik_result, tolerance);
 

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -296,6 +296,8 @@ bool StompPlanner::solve(planning_interface::MotionPlanDetailedResponse &res)
     }
 
     // creating request response
+    trajectory.header.seq=stomp_->getNumIterations(); //number of iterations
+    ROS_INFO_STREAM("Bruno this is your number of luck "<<trajectory.header.seq);
     moveit::core::RobotState robot_state(robot_model_);
     moveit::core::robotStateMsgToRobotState(request_.start_state,robot_state);
     res.trajectory_[0]= robot_trajectory::RobotTrajectoryPtr(new robot_trajectory::RobotTrajectory(
@@ -307,7 +309,7 @@ bool StompPlanner::solve(planning_interface::MotionPlanDetailedResponse &res)
     res.error_code_.val = moveit_msgs::MoveItErrorCodes::PLANNING_FAILED;
     return false;
   }
-  trajectory.header.seq=stomp_->getNumIterations(); //number of iterations
+
   // checking against planning scene
   if(planning_scene_ && !planning_scene_->isPathValid(*res.trajectory_.back(),group_,true))
   {

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -298,6 +298,8 @@ bool StompPlanner::solve(planning_interface::MotionPlanDetailedResponse &res)
     // creating request response
     trajectory.header.seq=stomp_->getNumIterations(); //number of iterations
     ROS_INFO_STREAM("Bruno this is your number of luck "<<trajectory.header.seq);
+    trajectory.points[0].effort.resize(1);
+    trajectory.points[0].effort[0]=stomp_->getNumIterations();
     moveit::core::RobotState robot_state(robot_model_);
     moveit::core::robotStateMsgToRobotState(request_.start_state,robot_state);
     res.trajectory_[0]= robot_trajectory::RobotTrajectoryPtr(new robot_trajectory::RobotTrajectory(

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -703,18 +703,11 @@ bool StompPlanner::ikFromCartesianConstraints(const moveit_msgs::PositionConstra
   KDL::Frame end_effector_pose;
 
   // some interfaces define position constraints as "target_point_offset" while others use "constraint_region"
-  if(pos_constraint.target_point_offset.x == pos_constraint.target_point_offset.y == pos_constraint.target_point_offset.z == 0.0)
+  if(not pos_constraint.constraint_region.primitive_poses.empty())
   {
-    if(pos_constraint.constraint_region.primitive_poses.empty())
-    {
-      end_effector_pose.p[0] = end_effector_pose.p[1] = end_effector_pose.p[2] = 0.0;
-    }
-    else
-    {
-      end_effector_pose.p[0] = pos_constraint.constraint_region.primitive_poses.front().position.x;
-      end_effector_pose.p[1] = pos_constraint.constraint_region.primitive_poses.front().position.y;
-      end_effector_pose.p[2] = pos_constraint.constraint_region.primitive_poses.front().position.z;
-    }
+    end_effector_pose.p[0] = pos_constraint.constraint_region.primitive_poses.front().position.x;
+    end_effector_pose.p[1] = pos_constraint.constraint_region.primitive_poses.front().position.y;
+    end_effector_pose.p[2] = pos_constraint.constraint_region.primitive_poses.front().position.z;
   }
   else
   {

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -908,10 +908,21 @@ bool StompPlanner::canServiceRequest(const moveit_msgs::MotionPlanRequest &req) 
     return false;
   }
 
-  // check that we have only joint constraints at the goal
-  if (req.goal_constraints[0].joint_constraints.size() == 0)
+  // make sure we have some constraints defined
+  if (req.goal_constraints[0].joint_constraints.size() == 0 and
+      req.goal_constraints[0].position_constraints.size() == 0 and
+      req.goal_constraints[0].orientation_constraints.size() == 0)
   {
-    ROS_ERROR("STOMP: Can only handle joint space goals.");
+    ROS_ERROR("STOMP: No constraints defined!");
+    return false;
+  }
+
+  // make sure we only have either joint constraints or cartesian constraints
+  if (req.goal_constraints[0].joint_constraints.size() > 0 and
+      req.goal_constraints[0].position_constraints.size() > 0 and
+      req.goal_constraints[0].orientation_constraints.size() > 0)
+  {
+    ROS_ERROR("STOMP: Too many constraints defined! Can only accept either joint or Cartesian constraints!");
     return false;
   }
 

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -560,7 +560,7 @@ bool StompPlanner::extractSeedCartesianTrajectory(const moveit_msgs::MotionPlanR
     seed.points.push_back(joint_pt);
   }
 
-  ROS_WARN_STREAM("Seed trajectory converted with a total of " << fail_count << " IK FAILURES");
+  ROS_WARN_STREAM("Seed trajectory converted with a total of " << fail_count << "/" << seed.points.size() << " IK FAILURES");
 
   seed.joint_names = joint_group->getActiveJointModelNames();
   return true;

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -665,7 +665,7 @@ bool StompPlanner::ikFromCartesianConstraints(const moveit_msgs::PositionConstra
   using namespace utils::kinematics;
 
   const double eps = 1e-3;
-  const double timeout = 0.01;
+  const double timeout = 0.05;
   const std::string urdf_param = "/robot_description";
 
 //  for(auto name : joint_group->getActiveJointModelNames())
@@ -702,7 +702,13 @@ bool StompPlanner::ikFromCartesianConstraints(const moveit_msgs::PositionConstra
     nominal.data = hint;
   }
 
-  int rc=tracik_solver.CartToJnt(nominal,end_effector_pose,ik_result);
+  KDL::Twist tolerance;
+  tolerance.rot.x(0.01);tolerance.rot.y(0.01);tolerance.rot.z(0.01);
+  tolerance.vel.x(0.01);tolerance.vel.y(0.01);tolerance.vel.z(0.01);
+
+  int rc=tracik_solver.CartToJnt(nominal,end_effector_pose,ik_result, tolerance);
+
+  ROS_WARN_STREAM(ik_result.data);
 
   if(rc >= 0)
   {

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -298,7 +298,7 @@ bool StompPlanner::solve(planning_interface::MotionPlanDetailedResponse &res)
     // creating request response
     trajectory.header.seq=stomp_->getNumIterations(); //number of iterations
     ROS_INFO_STREAM("Bruno this is your number of luck "<<trajectory.header.seq);
-    trajectory.points[0].effort.resize(1);
+    trajectory.points[0].effort.resize(trajectory.points[0].positions.size());
     trajectory.points[0].effort[0]=stomp_->getNumIterations();
     moveit::core::RobotState robot_state(robot_model_);
     moveit::core::robotStateMsgToRobotState(request_.start_state,robot_state);

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -666,12 +666,11 @@ bool StompPlanner::ikFromCartesianConstraints(const moveit_msgs::PositionConstra
 
   ROS_ASSERT(joint_group->getJointRoots().size() == 1);
 
-  //TODO: these frame names should be aligned with the frames of the demonstration, maybe send it in seed and retrieve here?
-  std::string chain_start = "base_link"; //TODO: get the link before the first joint here
-  std::string chain_end =  "gripper_grasping_frame"; //joint_group->getLinkModelNames().back();
+  const std::string base_frame = pos_constraint.header.frame_id;
+  const std::string end_eff_frame =  pos_constraint.link_name;
 
   //ROS_ERROR_STREAM("Setting up IK from " << chain_start << " to " << chain_end);
-  TRAC_IK::TRAC_IK tracik_solver(chain_start, chain_end, urdf_param, timeout, eps); //TODO: this should only be set up once per object, or use IK plugin?
+  TRAC_IK::TRAC_IK tracik_solver(base_frame, end_eff_frame, urdf_param, timeout, eps); //TODO: this should only be set up once per object, or use IK plugin?
   KDL::Chain chain;
   if(not tracik_solver.getKDLChain(chain))
     return false;

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -573,6 +573,24 @@ bool StompPlanner::ikFromCartesianConstraints(const moveit_msgs::PositionConstra
   return false;
 }
 
+bool StompPlanner::isCartesianSeed() const
+{
+  const auto& constraints = request_.trajectory_constraints.constraints; // alias to keep names short
+  ROS_ERROR_STREAM("We have a total of " << constraints.size() << " constraints");
+  if (constraints[0].joint_constraints.size() > 0)
+  {
+    ROS_ERROR_STREAM("We have " << constraints[0].joint_constraints.size() << " joint constraints");
+    return false;
+  }
+
+  if (constraints[0].position_constraints.size() > 0 and constraints[0].orientation_constraints.size() > 0)
+  {
+    ROS_ERROR_STREAM("We have " << constraints[0].position_constraints.size() << "  POSITION constraints");
+    ROS_ERROR_STREAM("We have " << constraints[0].orientation_constraints.size() << "  ORIENTATION constraints");
+    return true;
+  }
+}
+
 bool StompPlanner::getStartAndGoal(Eigen::VectorXd& start, Eigen::VectorXd& goal)
 {
   using namespace moveit::core;

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -518,7 +518,9 @@ bool StompPlanner::jointTrajectorytoParameters(const trajectory_msgs::JointTraje
   {
     for (size_t joint = 0; joint < dof; ++joint)
     {
-      mat(joint, step) = traj.points[step].positions[joint];
+      auto point = traj.points[step];
+      double val = point.positions[joint];
+      mat(joint, step) = val;
     }
   }
 
@@ -579,20 +581,21 @@ bool StompPlanner::extractSeedCartesianTrajectory(const moveit_msgs::MotionPlanR
   for (size_t i = 0; i < constraints[0].position_constraints.size(); ++i)
   {
     trajectory_msgs::JointTrajectoryPoint joint_pt;
+    joint_pt.positions.resize(joint_group->getActiveJointModelNames().size(), 0.0);
 
     if(ikFromCartesianConstraints(constraints[0].position_constraints[i],
                                   constraints[0].orientation_constraints[i],
                                   joint_group, joint_pos, joint_pos)) // passing the previous joint_pos as hint for the next one!
     {
       for(int j=0; j<joint_pos.size(); ++j)
-        joint_pt.positions.push_back(joint_pos(j));
+        joint_pt.positions[j] = joint_pos(j);
     }
     else
     {
       fail_count++;
-        // if IK fails on the seed we die here
+        // if IK fails on the seed we should die here...instead now only pruning
         ROS_ERROR_STREAM("**** FAILED TO IK CARTESIAN SEED at step " << i << " ******");
-//        return false;
+
         for(int j=0; j<joint_pos.size(); ++j)
           joint_pt.positions.push_back(joint_pos(j));
     }

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -712,12 +712,9 @@ bool StompPlanner::getStartAndGoal(Eigen::VectorXd& start, Eigen::VectorXd& goal
     ROS_ERROR("****************** Using cartesian seed ******************");
 
     // copying start joint values
-    ROS_ERROR("INitializing vectors");
     const std::vector<std::string> joint_names= state->getJointModelGroup(group_)->getActiveJointModelNames();
     start.setZero(joint_names.size());
     goal.setZero(joint_names.size());
-    ROS_ERROR_STREAM("Start joint state " << std::endl << start);
-    ROS_ERROR_STREAM("Goal joint state " << std::endl << goal);
 
         // CONVERT START STATE
     ROS_ERROR("Converting states");
@@ -729,13 +726,15 @@ bool StompPlanner::getStartAndGoal(Eigen::VectorXd& start, Eigen::VectorXd& goal
                                                   joint_group, start);
     ROS_ERROR_COND(!found_start, "STOMP failed to get the start positions");
     ROS_ERROR("Calculating goal state...");
-    found_goal = ikFromCartesianConstraints(position_constraints.back(), orientation_constraints.back(),
+    bool found_goal = ikFromCartesianConstraints(position_constraints.back(), orientation_constraints.back(),
                                             joint_group, goal);
     ROS_ERROR_COND(!found_goal, "STOMP failed to get the goal positions");
 
 
     ROS_ERROR_STREAM("Start joint state " << std::endl << start);
     ROS_ERROR_STREAM("Goal joint state " << std::endl << goal);
+
+    return found_goal and found_start;
   }
   else
   {

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -624,6 +624,14 @@ bool StompPlanner::extractSeedCartesianTrajectory(const moveit_msgs::MotionPlanR
   ROS_YELLOW_STREAM("IK solver is using " << base_frame << " for base frame and " << end_eff_frame << " for end effector frame");
 
   seed.joint_names = joint_group->getActiveJointModelNames();
+
+  double fail_percent = fail_count * 100.0 /constraints[0].position_constraints.size();
+  if(fail_percent > 30)
+  {
+    ROS_ERROR_STREAM("Too many failed IK calls when converting!");
+    return false;
+  }
+
   return true;
 }
 

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -708,8 +708,6 @@ bool StompPlanner::ikFromCartesianConstraints(const moveit_msgs::PositionConstra
 
   int rc=tracik_solver.CartToJnt(nominal,end_effector_pose,ik_result, tolerance);
 
-  ROS_WARN_STREAM(ik_result.data);
-
   if(rc >= 0)
   {
     //ROS_ERROR_STREAM("Shape of result is " << ik_result.data.rows() << " : " << ik_result.data.cols() << std::endl << ik_result.data);

--- a/stomp_moveit/src/stomp_planner.cpp
+++ b/stomp_moveit/src/stomp_planner.cpp
@@ -684,7 +684,7 @@ moveit_msgs::TrajectoryConstraints StompPlanner::encodeSeedTrajectory(const traj
 KDL::Frame StompPlanner::positionConstraintsToKDLFrame(const moveit_msgs::PositionConstraint& c) const
 {
   KDL::Frame result;
-    // some interfaces define position constraints as "target_point_offset" while others use "constraint_region"
+  // some interfaces define position constraints as "target_point_offset" while others use "constraint_region"
   if(not c.constraint_region.primitive_poses.empty())
   {
     result.p[0] = c.constraint_region.primitive_poses.front().position.x;
@@ -745,11 +745,6 @@ bool StompPlanner::ikFromCartesianConstraints(const moveit_msgs::PositionConstra
   }
   else
   {
-    ROS_ERROR("Failed to get IK");
-    ROS_WARN_STREAM(pos_constraint.constraint_region);
-    ROS_WARN_STREAM(pos_constraint.target_point_offset);
-    ROS_WARN_STREAM(orient_constraint.orientation);
-
     ROS_WHITE_STREAM("IK queried EEF pose: (" <<
                      end_effector_pose.p[0] << ", " <<
                      end_effector_pose.p[1] << ", " <<
@@ -798,12 +793,6 @@ moveit_msgs::RobotState StompPlanner::robotStateFromEigen(const Eigen::MatrixXd&
         result.joint_state.position[i] = state(j,0);
     }
   }
-
-//  ROS_GREEN_STREAM(result.joint_state.name);
-//  ROS_GREEN_STREAM(result.joint_state.position);
-
-//  ROS_CYAN_STREAM(state_joint_names);
-//  ROS_CYAN_STREAM(state);
 
   return result;
 }


### PR DESCRIPTION
This is a feature we worked on for our Guided STOMP paper. The implementation needs plenty of cleanup but I'd like to have some feedback on this.

It adds support for passing in a Cartesian seed trajectory which gets converted with `trac_ik` at the moment.

* My experience with the current setup phase of STOMP is that it's way too stateful for what it is. A more major refactor could simplify it a lot.

* Why is there a pseudoinverse jacobian IK within STOMP? I removed the use of that, `trac_ik` performs much better. Even better: IK calls should probably be done through the RobotState class with [`setFromIK`](http://docs.ros.org/jade/api/moveit_core/html/classmoveit_1_1core_1_1RobotState.html#ab816880027ef7e63bbdef22a0497cc78) which will call whatever IK solver is set up for the whole of MoveIt.

Any feedback is welcome :) 