### PR TITLE
Update of xacro command and format

### DIFF
--- a/stomp_test_kr210_moveit_config/launch/planning_context.launch
+++ b/stomp_test_kr210_moveit_config/launch/planning_context.launch
@@ -6,11 +6,11 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro.py '$(find stomp_test_support)/urdf/test_kr210l150.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro '$(find stomp_test_support)/urdf/test_kr210l150.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find stomp_test_kr210_moveit_config)/config/test_kr210.srdf" />
-  
+
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description)_planning">
     <rosparam command="load" file="$(find stomp_test_kr210_moveit_config)/config/joint_limits.yaml"/>
@@ -20,5 +20,5 @@
   <group ns="$(arg robot_description)_kinematics">
     <rosparam command="load" file="$(find stomp_test_kr210_moveit_config)/config/kinematics.yaml"/>
   </group>
-  
+
 </launch>

--- a/stomp_test_kr210_moveit_config/launch/planning_context.launch
+++ b/stomp_test_kr210_moveit_config/launch/planning_context.launch
@@ -6,7 +6,7 @@
   <arg name="robot_description" default="robot_description"/>
 
   <!-- Load universal robot description format (URDF) -->
-  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro '$(find stomp_test_support)/urdf/test_kr210l150.xacro'"/>
+  <param if="$(arg load_robot_description)" name="$(arg robot_description)" command="$(find xacro)/xacro --inorder '$(find stomp_test_support)/urdf/test_kr210l150.xacro'"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <param name="$(arg robot_description)_semantic" textfile="$(find stomp_test_kr210_moveit_config)/config/test_kr210.srdf" />

--- a/stomp_test_support/urdf/kr210l150_macro.xacro
+++ b/stomp_test_support/urdf/kr210l150_macro.xacro
@@ -1,6 +1,5 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
 
-	<xacro:property name="pi" value="3.141592654" />
 	<xacro:property name="deg" value="0.017453293" /> <!--degrees to radians-->
 	
 	<xacro:macro name="kuka_kr210l150" params="prefix">

--- a/stomp_test_support/urdf/kr210l150_macro.xacro
+++ b/stomp_test_support/urdf/kr210l150_macro.xacro
@@ -1,4 +1,4 @@
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
 
 	<property name="pi" value="3.141592654" />
 	<property name="deg" value="0.017453293" /> <!--degrees to radians-->

--- a/stomp_test_support/urdf/kr210l150_macro.xacro
+++ b/stomp_test_support/urdf/kr210l150_macro.xacro
@@ -1,7 +1,7 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
 
-	<property name="pi" value="3.141592654" />
-	<property name="deg" value="0.017453293" /> <!--degrees to radians-->
+	<xacro:property name="pi" value="3.141592654" />
+	<xacro:property name="deg" value="0.017453293" /> <!--degrees to radians-->
 	
 	<xacro:macro name="kuka_kr210l150" params="prefix">
 

--- a/stomp_test_support/urdf/simple_2fgripper_macro.xacro
+++ b/stomp_test_support/urdf/simple_2fgripper_macro.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
 	<!-- parameter list -->
 	<xacro:property name="gripper_length" value="0.24"/>
 	<xacro:property name="gripper_width" value="0.04"/>

--- a/stomp_test_support/urdf/test_kr210l150.xacro
+++ b/stomp_test_support/urdf/test_kr210l150.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<robot name="test_kr210" xmlns:xacro="http://ros.org/wiki/xacro">
+<robot name="test_kr210" xmlns:xacro="http://wiki.ros.org/xacro">
   <xacro:include filename="$(find stomp_test_support)/urdf/kr210l150_macro.xacro"/>
   <xacro:kuka_kr210l150 prefix=""/>
   <xacro:include filename="$(find stomp_test_support)/urdf/test_kr210l150_macro.xacro"/>

--- a/stomp_test_support/urdf/test_kr210l150_macro.xacro
+++ b/stomp_test_support/urdf/test_kr210l150_macro.xacro
@@ -2,7 +2,7 @@
 
 <!--Generates a urdf from the macro in kr210_macro.xacro -->
 
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://wiki.ros.org/xacro">
 
 <xacro:property name="rail_cross_section" value="0.1"/>
 <xacro:property name="workcell_width" value="5.0"/>


### PR DESCRIPTION
Hi there. The STOMP is very nice planner. Thank you for your consistent maintenance.

I found the warning message when calling the following roslaunch file.

```
$ roslaunch stomp_test_kr210_moveit_config demo.launch
... logging to ${HOME}/.ros/log/5f589f32-7a99-11e8-b512-001c4274c9d5/roslaunch-${HOST}-8059.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

inconsistent namespace redefinitions for xmlns:xacro:
 old: http://ros.org/wiki/xacro
 new: http://wiki.ros.org/xacro (${ROS_WORKSPACE}/src/motion-opt/fanuc/fanuc_resources/urdf/common_materials.xacro)
...
```

So I replace it to new one. Then the next warning and suggestion were displayed.

```
$ roslaunch stomp_test_kr210_moveit_config demo.launch
... logging to ${HOME}/.ros/log/1184af14-7add-11e8-b512-001c4274c9d5/roslaunch-${HOST}-11568.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

xacro: Traditional processing is deprecated. Switch to --inorder processing!
To check for compatibility of your document, use option --check-order.
For more infos, see http://wiki.ros.org/xacro#Processing_Order
deprecated: xacro tags should be prepended with 'xacro' xml namespace.
Use the following script to fix incorrect usage:
        find . -iname "*.xacro" | xargs sed -i 's#<\([/]\?\)\(if\|unless\|include\|arg\|property\|macro\|insert_block\)#<\1xacro:\2#g'
when processing file: ${ROS_WORKSPACE}/src/industrial_moveit/stomp_test_support/urdf/test_kr210l150.xacro

redefining global property: pi
when processing file: ${ROS_WORKSPACE}/src/industrial_moveit/stomp_test_support/urdf/test_kr210l150.xacro
xacro.py is deprecated; please use xacro instead
...
```

This PR fixes their waring.

Environment:
- OS: Ubuntu 16.04
- ROS: kinetic