### PR TITLE
Fix Dependencies for stomp_moveit

### DIFF
--- a/stomp_moveit/CMakeLists.txt
+++ b/stomp_moveit/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   pluginlib
   kdl_parser
   trac_ik_lib
+  eigen_conversions
 )
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)

--- a/stomp_moveit/package.xml
+++ b/stomp_moveit/package.xml
@@ -19,6 +19,7 @@
   <build_depend>cmake_modules</build_depend>
   <build_depend>kdl_parser</build_depend>
   <build_depend>trac_ik_lib</build_depend>
+  <build_depend>eigen_conversions</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
@@ -28,6 +29,7 @@
   <run_depend>cmake_modules</run_depend>
   <run_depend>kdl_parser</run_depend>
   <run_depend>trac_ik_lib</run_depend>
+  <run_depend>eigen_conversions</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
Fixes symbolic look up error caused by tf::pointEigenToMsg used in `multi_trajectory_visualization.cpp` when visualising stomp motion plan in RVIZ. 