### PR TITLE
Changed industrial_moveit_test_support license from TODO to Apache 2.0 in package.xml

### DIFF
--- a/industrial_moveit_test_support/package.xml
+++ b/industrial_moveit_test_support/package.xml
@@ -4,7 +4,7 @@
   <version>0.1.1</version>
   <description>The industrial_moveit_test_support package</description>
   <maintainer email="jnicho@swri.org">Jorge Nicho</maintainer>
-  <license>TODO</license>
+  <license>Apache 2.0</license>
   <author email="jnicho@swri.org">Jorge Nicho</author>
 
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
Addresses #94 , related to https://github.com/ros-industrial/ros_industrial_issues/issues/57